### PR TITLE
Add_buckets_and_policies

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,24 +1,17 @@
-
 data "aws_iam_policy_document" "packer_assume_role_policy_document" {
   statement {
-    sid    = "PackerAssumeRole"
-    effect = "Allow"
-    actions = [
-      "sts:AssumeRole"
-    ]
+    sid     = "PackerAssumeRole"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
     principals {
       type        = "AWS"
-      identifiers = [
-        "arn:${data.aws_partition.current.partition}:iam::${var.account_number}:root"
-        ]
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.account_number}:root"]
     }
   }
   statement {
-    sid    = "PackerEC2AssumeRole"
-    effect = "Allow"
-    actions = [
-      "sts:AssumeRole"
-    ]
+    sid     = "PackerEC2AssumeRole"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
     principals {
       type        = "Service"
       identifiers = ["ec2.amazonaws.com"]
@@ -81,9 +74,7 @@ data "aws_iam_policy_document" "packer_policy_document" {
       "ec2:ReplaceIamInstanceProfileAssociation",
       "iam:GetInstanceProfile"
     ]
-    resources = [
-      "*"
-    ]
+    resources = ["*"]
   }
 
   statement {
@@ -112,18 +103,13 @@ data "aws_iam_policy_document" "packer_policy_document" {
     resources = [
       "arn:${data.aws_partition.current.partition}:ssm:${var.aws_region}:${var.account_number}:parameter/production/packer/*",
       "arn:${data.aws_partition.current.partition}:ssm:${var.aws_region}:${var.account_number}:parameter/production/ca_secrets_path",
-      "arn:${data.aws_partition.current.partition}:ssm:${var.aws_region}:${var.account_number}:parameter/production/siem",
       "arn:${data.aws_partition.current.partition}:ssm:${var.aws_region}:${var.account_number}:parameter/production/mgmt/ca/rootca/root_ca_pub.pem"
     ]
   }
   statement {
-    effect = "Allow"
-    actions = [
-      "ssm:DescribeParameters"
-    ]
-    resources = [
-      "*"
-    ]
+    effect    = "Allow"
+    actions   = ["ssm:DescribeParameters"]
+    resources = ["*"]
   }
   statement {
     sid    = "PackerEBSEncrypt"
@@ -137,9 +123,7 @@ data "aws_iam_policy_document" "packer_policy_document" {
       "kms:CreateGrant",
       "kms:ListGrants"
     ]
-    resources = [
-      "*"
-    ]
+    resources = ["*"]
   }
 }
 
@@ -168,7 +152,8 @@ resource "aws_kms_grant" "packer_s3" {
   operations = [
     "Encrypt",
     "Decrypt",
-  "DescribeKey"]
+    "DescribeKey"
+  ]
 }
 resource "aws_kms_grant" "packer_ebs" {
   name              = "packer-${var.aws_region}-ebs-access"
@@ -177,5 +162,6 @@ resource "aws_kms_grant" "packer_ebs" {
   operations = [
     "Encrypt",
     "Decrypt",
-  "DescribeKey"]
+    "DescribeKey"
+  ]
 }

--- a/kms.tf
+++ b/kms.tf
@@ -1,7 +1,7 @@
 module "ebs_kms_key" {
   count = var.create_ebs_kms_key ? 1 : 0
 
-  source = "github.com/Coalfire-CF/terraform-aws-kms"
+  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v0.0.6"
 
   key_policy            = data.aws_iam_policy_document.ebs_key.json
   kms_key_resource_type = "ebs"
@@ -74,7 +74,7 @@ data "aws_iam_policy_document" "ebs_key" {
 
 module "sm_kms_key" {
   count  = var.create_sm_kms_key ? 1 : 0
-  source = "github.com/Coalfire-CF/terraform-aws-kms"
+  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v0.0.6"
 
   key_policy            = data.aws_iam_policy_document.secrets_manager_key.json
   kms_key_resource_type = "sm"
@@ -112,7 +112,7 @@ data "aws_iam_policy_document" "secrets_manager_key" {
 
 module "backup_kms_key" {
   count  = var.create_backup_kms_key ? 1 : 0
-  source = "github.com/Coalfire-CF/terraform-aws-kms"
+  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v0.0.6"
 
   key_policy            = module.security-core.s3_key_iam
   kms_key_resource_type = "backup"
@@ -121,7 +121,7 @@ module "backup_kms_key" {
 
 module "lambda_kms_key" {
   count  = var.create_lambda_kms_key ? 1 : 0
-  source = "github.com/Coalfire-CF/terraform-aws-kms"
+  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v0.0.6"
 
   kms_key_resource_type = "lambda"
   resource_prefix       = var.resource_prefix
@@ -129,7 +129,7 @@ module "lambda_kms_key" {
 
 module "rds_kms_key" {
   count  = var.create_rds_kms_key ? 1 : 0
-  source = "github.com/Coalfire-CF/terraform-aws-kms"
+  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v0.0.6"
 
   kms_key_resource_type = "rds"
   resource_prefix       = var.resource_prefix
@@ -137,16 +137,16 @@ module "rds_kms_key" {
 
 module "cloudwatch_kms_key" {
   count  = var.create_cloudwatch_kms_key ? 1 : 0
-  source = "github.com/Coalfire-CF/terraform-aws-kms"
+  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v0.0.6"
 
   kms_key_resource_type = "cloudwatch"
   resource_prefix       = var.resource_prefix
-  key_policy = data.aws_iam_policy_document.cloudwatch_key.json
+  key_policy            = data.aws_iam_policy_document.cloudwatch_key.json
 }
 
 module "additional_kms_keys" {
-  source   = "github.com/Coalfire-CF/terraform-aws-kms"
-  for_each = { for key in var.additional_kms_keys : key.name => key}
+  source   = "github.com/Coalfire-CF/terraform-aws-kms?ref=v0.0.6"
+  for_each = { for key in var.additional_kms_keys : key.name => key }
 
   key_policy            = each.value.policy
   kms_key_resource_type = each.value.name

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,6 +2,10 @@ output "s3_access_logs_arn" {
   value = module.s3-accesslogs.arn
 }
 
+output "s3_elb_access_logs_arn" {
+  value = module.s3-elb-accesslogs.arn
+}
+
 output "s3_backups_arn" {
   value = module.s3-backups.arn
 }
@@ -12,6 +16,10 @@ output "s3_installs_arn" {
 
 output "s3_access_logs_id" {
   value = module.s3-accesslogs.id
+}
+
+output "s3_elb_access_logs_id" {
+  value = module.s3-elb-accesslogs.id
 }
 
 output "s3_backups_id" {

--- a/s3-accesslog.tf
+++ b/s3-accesslog.tf
@@ -1,10 +1,67 @@
 module "s3-accesslogs" {
-  source = "github.com/Coalfire-CF/terraform-aws-s3"
+  #checkov:skip=CKV_AWS_145: "Ensure that S3 buckets are encrypted with KMS by default"
+  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.0"
 
-  name                    = "${var.resource_prefix}-${var.aws_region}-accesslogs"
-  kms_master_key_id       = module.security-core.s3_key_id
+  name                    = "${var.resource_prefix}-${var.aws_region}-s3-accesslogs"
   attach_public_policy    = false
   block_public_acls       = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+
+  # Note: S3 Access Logs bucket MUST use AES256, will not work with customer KMS
+  # https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html
+  enable_kms = false
+}
+
+data "aws_iam_policy_document" "s3_accesslogs_bucket_policy" {
+  statement {
+    actions = ["s3:GetBucketAcl"]
+    effect  = "Allow"
+    principals {
+      identifiers = ["delivery.logs.amazonaws.com"]
+      type        = "Service"
+    }
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.resource_prefix}-${var.aws_region}-s3-accesslogs"]
+  }
+
+  statement {
+    actions = ["s3:PutObject"]
+    effect  = "Allow"
+    principals {
+      identifiers = ["delivery.logs.amazonaws.com"]
+      type        = "Service"
+    }
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.resource_prefix}-${var.aws_region}-s3-accesslogs/*"]
+    condition {
+      test     = "StringEquals"
+      values   = ["bucket-owner-full-control"]
+      variable = "s3:x-amz-acl"
+    }
+  }
+  statement {
+    actions = ["s3:PutObject"]
+    effect  = "Allow"
+    principals {
+      identifiers = ["logging.s3.amazonaws.com"]
+      type        = "Service"
+    }
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.resource_prefix}-${var.aws_region}-s3-accesslogs/*"]
+  }
+  dynamic "statement" {
+    for_each = var.application_account_numbers
+    content {
+      actions = ["s3:PutObject"]
+      effect  = "Allow"
+      principals {
+        identifiers = [statement.value]
+        type        = "AWS"
+      }
+      condition {
+        test     = "StringEquals"
+        variable = "s3:x-amz-acl"
+        values   = ["bucket-owner-full-control"]
+      }
+      resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.resource_prefix}-${var.aws_region}-s3-accesslogs/*"]
+    }
+  }
 }

--- a/s3-accesslog.tf
+++ b/s3-accesslog.tf
@@ -11,6 +11,10 @@ module "s3-accesslogs" {
   # Note: S3 Access Logs bucket MUST use AES256, will not work with customer KMS
   # https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html
   enable_kms = false
+
+  # Bucket Policy
+  bucket_policy           = true
+  aws_iam_policy_document = data.aws_iam_policy_document.s3_accesslogs_bucket_policy.json
 }
 
 data "aws_iam_policy_document" "s3_accesslogs_bucket_policy" {

--- a/s3-backups.tf
+++ b/s3-backups.tf
@@ -9,6 +9,7 @@ module "s3-backups" {
   restrict_public_buckets = true
 
   # S3 Access Logs
+  logging       = true
   target_bucket = module.s3-accesslogs.id
   target_prefix = "backups/"
 }

--- a/s3-backups.tf
+++ b/s3-backups.tf
@@ -1,5 +1,5 @@
 module "s3-backups" {
-  source = "github.com/Coalfire-CF/terraform-aws-s3"
+  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.0"
 
   name                    = "${var.resource_prefix}-${var.aws_region}-backups"
   kms_master_key_id       = module.security-core.s3_key_id
@@ -7,4 +7,8 @@ module "s3-backups" {
   block_public_acls       = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+
+  # S3 Access Logs
+  target_bucket = module.s3-accesslogs.id
+  target_prefix = "backups/"
 }

--- a/s3-elb-accesslog.tf
+++ b/s3-elb-accesslog.tf
@@ -18,10 +18,12 @@ module "s3-elb-accesslogs" {
 }
 
 locals {
-  # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
+  # Note: This is specifically for Classic Load Balancer to give write access to ELB Access Logs S3 Bucket
+  # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html
   aws_lb_account_ids = {
     us-east-2     = "033677994240"
     us-east-1     = "127311923021"
+    us-west-1     = "027434742980"
     us-west-2     = "797873946194"
     us-gov-west-1 = "048591011584"
     us-gov-east-1 = "190560391635"

--- a/s3-elb-accesslog.tf
+++ b/s3-elb-accesslog.tf
@@ -16,6 +16,10 @@ module "s3-elb-accesslogs" {
   logging       = true
   target_bucket = module.s3-accesslogs.id
   target_prefix = "elb-accesslogs/"
+
+  # Bucket Policy
+  bucket_policy           = true
+  aws_iam_policy_document = data.aws_iam_policy_document.elb_accesslogs_bucket_policy.json
 }
 
 locals {

--- a/s3-elb-accesslog.tf
+++ b/s3-elb-accesslog.tf
@@ -1,0 +1,82 @@
+module "s3-elb-accesslogs" {
+  #checkov:skip=CKV_AWS_145: "Ensure that S3 buckets are encrypted with KMS by default"
+  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.0"
+
+  name                    = "${var.resource_prefix}-${var.aws_region}-elb-accesslogs"
+  attach_public_policy    = false
+  block_public_acls       = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  # https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#enable-access-logs-troubleshooting
+  # KMS keys are not supported for Classic Load Balancer logging
+  enable_kms = false
+
+  # S3 Access Logs
+  target_bucket = module.s3-accesslogs.id
+  target_prefix = "elb-accesslogs/"
+}
+
+locals {
+  # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
+  aws_lb_account_ids = {
+    us-east-2     = "033677994240"
+    us-east-1     = "127311923021"
+    us-west-2     = "797873946194"
+    us-gov-west-1 = "048591011584"
+    us-gov-east-1 = "190560391635"
+  }
+}
+
+data "aws_iam_policy_document" "elb_accesslogs_bucket_policy" {
+  statement {
+    actions = ["s3:GetBucketAcl"]
+    effect  = "Allow"
+    principals {
+      identifiers = ["delivery.logs.amazonaws.com"]
+      type        = "Service"
+    }
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.resource_prefix}-${var.aws_region}-elb-accesslogs"]
+  }
+
+  statement {
+    actions = ["s3:PutObject"]
+    effect  = "Allow"
+    principals {
+      identifiers = ["delivery.logs.amazonaws.com"]
+      type        = "Service"
+    }
+    resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.resource_prefix}-${var.aws_region}-elb-accesslogs/*"]
+    condition {
+      test     = "StringEquals"
+      values   = ["bucket-owner-full-control"]
+      variable = "s3:x-amz-acl"
+    }
+  }
+
+  statement {
+    actions = ["s3:PutObject"]
+    effect  = "Allow"
+    principals {
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${local.aws_lb_account_ids[var.aws_region]}:root"]
+      type        = "AWS"
+    }
+    resources = [
+      "arn:${data.aws_partition.current.partition}:s3:::${var.resource_prefix}-${var.aws_region}-elb-accesslogs/lb/AWSLogs/${var.account_number}/*",
+
+    ]
+  }
+
+  dynamic "statement" {
+    for_each = var.application_account_numbers
+    content {
+      actions = ["s3:PutObject"]
+      effect  = "Allow"
+      principals {
+        identifiers = ["arn:${data.aws_partition.current.partition}:iam::${local.aws_lb_account_ids[var.aws_region]}:root"]
+        type        = "AWS"
+      }
+      resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.resource_prefix}-${var.aws_region}-elb-accesslogs/lb/AWSLogs/${statement.value}/*"]
+    }
+  }
+}

--- a/s3-elb-accesslog.tf
+++ b/s3-elb-accesslog.tf
@@ -13,6 +13,7 @@ module "s3-elb-accesslogs" {
   enable_kms = false
 
   # S3 Access Logs
+  logging       = true
   target_bucket = module.s3-accesslogs.id
   target_prefix = "elb-accesslogs/"
 }

--- a/s3-install.tf
+++ b/s3-install.tf
@@ -9,6 +9,7 @@ module "s3-installs" {
   restrict_public_buckets = true
 
   # S3 Access Logs
+  logging       = true
   target_bucket = module.s3-accesslogs.id
   target_prefix = "installs/"
 }

--- a/s3-install.tf
+++ b/s3-install.tf
@@ -1,5 +1,5 @@
 module "s3-installs" {
-  source = "github.com/Coalfire-CF/terraform-aws-s3"
+  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.0"
 
   name                    = "${var.resource_prefix}-${var.aws_region}-installs"
   kms_master_key_id       = module.security-core.s3_key_id
@@ -7,4 +7,8 @@ module "s3-installs" {
   block_public_acls       = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+
+  # S3 Access Logs
+  target_bucket = module.s3-accesslogs.id
+  target_prefix = "installs/"
 }

--- a/security-core.tf
+++ b/security-core.tf
@@ -1,5 +1,5 @@
 module "security-core" {
-  source = "github.com/Coalfire-CF/terraform-aws-securitycore"
+  source = "github.com/Coalfire-CF/terraform-aws-securitycore?ref=v0.0.15"
 
   account_number              = var.account_number
   application_account_numbers = var.application_account_numbers

--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,7 @@ variable "resource_prefix" {
 variable "create_cloudtrail" {
   description = "Whether or not to create cloudtrail resources"
   type        = bool
-  default = false
+  default     = false
 }
 
 variable "lambda_time_zone" {
@@ -50,7 +50,7 @@ variable "aws_lb_account_ids" {
 variable "enable_aws_config" {
   description = "Enable AWS config for this account"
   type        = bool
-    default = false
+  default     = false
 
 }
 
@@ -87,8 +87,8 @@ variable "backup_vault_name" {
 
 variable "delete_after" {
   description = "Number of days after which a recovery point should be deleted"
-  type = number
-  default = 35
+  type        = number
+  default     = 35
 }
 
 variable "additional_kms_keys" {


### PR DESCRIPTION
Changes:
- ELB Access Logs only allow logging to S3 bucket by default, therefore it seemed sensible to add this bucket as part of the initial account setup.
- Not entirely clear what the "accesslogs" bucket is for.  Clearly defined 2 separate buckets as "s3-accesslogs" and "elb-accesslogs" to remove ambiguity.
-Both buckets require a defined bucket policy for their respective services to allow logging, I have defined these policies and added them as arguments for the s3 module.
-Added git tag reference to all "source" calls.  Created and/or updated these tags in downstream modules where they didn't exist (s3), or where the latest commit hash didn't match the latest tag (kms, securitycore).