### PR TITLE
Elb_accesslog_fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ module "account-setup" {
 | <a name="module_ebs_kms_key"></a> [ebs\_kms\_key](#module\_ebs\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
 | <a name="module_lambda_kms_key"></a> [lambda\_kms\_key](#module\_lambda\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
 | <a name="module_rds_kms_key"></a> [rds\_kms\_key](#module\_rds\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
-| <a name="module_s3-accesslogs"></a> [s3-accesslogs](#module\_s3-accesslogs) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.0 |
-| <a name="module_s3-backups"></a> [s3-backups](#module\_s3-backups) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.0 |
-| <a name="module_s3-elb-accesslogs"></a> [s3-elb-accesslogs](#module\_s3-elb-accesslogs) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.0 |
-| <a name="module_s3-installs"></a> [s3-installs](#module\_s3-installs) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.0 |
-| <a name="module_security-core"></a> [security-core](#module\_security-core) | github.com/Coalfire-CF/terraform-aws-securitycore | v0.0.15 |
+| <a name="module_s3-accesslogs"></a> [s3-accesslogs](#module\_s3-accesslogs) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.1 |
+| <a name="module_s3-backups"></a> [s3-backups](#module\_s3-backups) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.1 |
+| <a name="module_s3-elb-accesslogs"></a> [s3-elb-accesslogs](#module\_s3-elb-accesslogs) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.1 |
+| <a name="module_s3-installs"></a> [s3-installs](#module\_s3-installs) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.1 |
+| <a name="module_security-core"></a> [security-core](#module\_security-core) | github.com/Coalfire-CF/terraform-aws-securitycore | v0.0.17 |
 | <a name="module_sm_kms_key"></a> [sm\_kms\_key](#module\_sm\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
 
 ## Resources
@@ -83,6 +83,7 @@ module "account-setup" {
 | [aws_iam_role.packer_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_kms_grant.packer_ebs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_grant) | resource |
 | [aws_kms_grant.packer_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_grant) | resource |
+| [aws_elb_service_account.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_service_account) | data source |
 | [aws_iam_policy_document.cloudwatch_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ebs_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.elb_accesslogs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/s3-accesslog.tf
+++ b/s3-accesslog.tf
@@ -1,6 +1,6 @@
 module "s3-accesslogs" {
   #checkov:skip=CKV_AWS_145: "Ensure that S3 buckets are encrypted with KMS by default"
-  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.0"
+  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.1"
 
   name                    = "${var.resource_prefix}-${var.aws_region}-s3-accesslogs"
   attach_public_policy    = false

--- a/s3-backups.tf
+++ b/s3-backups.tf
@@ -1,5 +1,5 @@
 module "s3-backups" {
-  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.0"
+  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.1"
 
   name                    = "${var.resource_prefix}-${var.aws_region}-backups"
   kms_master_key_id       = module.security-core.s3_key_id

--- a/s3-elb-accesslog.tf
+++ b/s3-elb-accesslog.tf
@@ -54,7 +54,7 @@ data "aws_iam_policy_document" "elb_accesslogs_bucket_policy" {
     actions = ["s3:PutObject"]
     effect  = "Allow"
     principals {
-      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_elb_service_account.main.arn}:root"]
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_elb_service_account.main.id}:root"]
       type        = "AWS"
     }
     resources = [
@@ -69,7 +69,7 @@ data "aws_iam_policy_document" "elb_accesslogs_bucket_policy" {
       actions = ["s3:PutObject"]
       effect  = "Allow"
       principals {
-        identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_elb_service_account.main.arn}:root"]
+        identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_elb_service_account.main.id}:root"]
         type        = "AWS"
       }
       resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.resource_prefix}-${var.aws_region}-elb-accesslogs/lb/AWSLogs/${statement.value}/*"]

--- a/s3-elb-accesslog.tf
+++ b/s3-elb-accesslog.tf
@@ -21,19 +21,8 @@ module "s3-elb-accesslogs" {
   bucket_policy           = true
   aws_iam_policy_document = data.aws_iam_policy_document.elb_accesslogs_bucket_policy.json
 }
-
-locals {
-  # Note: This is specifically for Classic Load Balancer to give write access to ELB Access Logs S3 Bucket
-  # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html
-  aws_lb_account_ids = {
-    us-east-2     = "033677994240"
-    us-east-1     = "127311923021"
-    us-west-1     = "027434742980"
-    us-west-2     = "797873946194"
-    us-gov-west-1 = "048591011584"
-    us-gov-east-1 = "190560391635"
-  }
-}
+# https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html
+data "aws_elb_service_account" "main" {}
 
 data "aws_iam_policy_document" "elb_accesslogs_bucket_policy" {
   statement {
@@ -65,12 +54,12 @@ data "aws_iam_policy_document" "elb_accesslogs_bucket_policy" {
     actions = ["s3:PutObject"]
     effect  = "Allow"
     principals {
-      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${local.aws_lb_account_ids[var.aws_region]}:root"]
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_elb_service_account.main.arn}:root"]
       type        = "AWS"
     }
     resources = [
       "arn:${data.aws_partition.current.partition}:s3:::${var.resource_prefix}-${var.aws_region}-elb-accesslogs/lb/AWSLogs/${var.account_number}/*",
-
+      "arn:${data.aws_partition.current.partition}:s3:::${var.resource_prefix}-${var.aws_region}-elb-accesslogs/AWSLogs/${var.account_number}/*"
     ]
   }
 
@@ -80,7 +69,7 @@ data "aws_iam_policy_document" "elb_accesslogs_bucket_policy" {
       actions = ["s3:PutObject"]
       effect  = "Allow"
       principals {
-        identifiers = ["arn:${data.aws_partition.current.partition}:iam::${local.aws_lb_account_ids[var.aws_region]}:root"]
+        identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_elb_service_account.main.arn}:root"]
         type        = "AWS"
       }
       resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.resource_prefix}-${var.aws_region}-elb-accesslogs/lb/AWSLogs/${statement.value}/*"]

--- a/s3-elb-accesslog.tf
+++ b/s3-elb-accesslog.tf
@@ -1,6 +1,6 @@
 module "s3-elb-accesslogs" {
   #checkov:skip=CKV_AWS_145: "Ensure that S3 buckets are encrypted with KMS by default"
-  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.0"
+  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.1"
 
   name                    = "${var.resource_prefix}-${var.aws_region}-elb-accesslogs"
   attach_public_policy    = false

--- a/s3-install.tf
+++ b/s3-install.tf
@@ -1,5 +1,5 @@
 module "s3-installs" {
-  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.0"
+  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.1"
 
   name                    = "${var.resource_prefix}-${var.aws_region}-installs"
   kms_master_key_id       = module.security-core.s3_key_id

--- a/security-core.tf
+++ b/security-core.tf
@@ -1,5 +1,5 @@
 module "security-core" {
-  source = "github.com/Coalfire-CF/terraform-aws-securitycore?ref=v0.0.15"
+  source = "github.com/Coalfire-CF/terraform-aws-securitycore?ref=7adde37eec178c0243f7de4709f1713c07f82401"
 
   account_number              = var.account_number
   application_account_numbers = var.application_account_numbers

--- a/security-core.tf
+++ b/security-core.tf
@@ -1,5 +1,5 @@
 module "security-core" {
-  source = "github.com/Coalfire-CF/terraform-aws-securitycore?ref=7adde37eec178c0243f7de4709f1713c07f82401"
+  source = "github.com/Coalfire-CF/terraform-aws-securitycore?ref=v0.0.17"
 
   account_number              = var.account_number
   application_account_numbers = var.application_account_numbers


### PR DESCRIPTION
# Security Core
- Pin version to latest v0.0.17.

# S3
- Update S3 module to v1.0.1, which sets correct lifecycle rules to ensure stale objects are correctly expired and transitioned.
- Update ELB access logs, remove static "locals.aws_lb_account_ids" values and replace with data.aws_elb_service_account.main so that the ids are retrieved dynamically instead of being hardcoded.