### PR TITLE
Fix for empty account numbers list open issue

### DIFF
--- a/kms.tf
+++ b/kms.tf
@@ -75,7 +75,7 @@ data "aws_iam_policy_document" "ebs_key" {
   }
 
   dynamic "statement" {
-    for_each = var.application_account_numbers
+    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
     content {
       effect = "Allow"
       actions = [
@@ -96,7 +96,7 @@ data "aws_iam_policy_document" "ebs_key" {
     }
   }
   dynamic "statement" {
-    for_each = var.application_account_numbers
+    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
     content {
       effect = "Allow"
       actions = [
@@ -138,7 +138,7 @@ data "aws_iam_policy_document" "s3_key" {
   # https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html
 
   dynamic "statement" {
-    for_each = var.application_account_numbers
+    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
     content {
       effect    = "Allow"
       actions   = ["kms:*"]
@@ -211,7 +211,7 @@ data "aws_iam_policy_document" "s3_key" {
   }
 
   dynamic "statement" {
-    for_each = var.application_account_numbers
+    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
     content {
       effect    = "Allow"
       actions   = ["kms:GenerateDataKey*"]
@@ -254,7 +254,7 @@ data "aws_iam_policy_document" "sns_key" {
     }
   }
   dynamic "statement" {
-    for_each = var.application_account_numbers
+    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
     content {
       effect = "Allow"
       actions = [
@@ -291,7 +291,7 @@ data "aws_iam_policy_document" "secrets_manager_key" {
   # https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html
 
   dynamic "statement" {
-    for_each = var.application_account_numbers
+    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
     content {
       effect    = "Allow"
       actions   = ["kms:*"]
@@ -364,7 +364,7 @@ data "aws_iam_policy_document" "cloudwatch_key" {
   # https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html
 
   dynamic "statement" {
-    for_each = var.application_account_numbers
+    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
     content {
       effect    = "Allow"
       actions   = ["kms:*"]
@@ -437,7 +437,7 @@ data "aws_iam_policy_document" "cloudwatch_key" {
   }
 
   dynamic "statement" {
-    for_each = var.application_account_numbers
+    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
     content {
       effect    = "Allow"
       actions   = ["kms:GenerateDataKey*"]
@@ -470,7 +470,7 @@ data "aws_iam_policy_document" "config_key" {
   # https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html
 
   dynamic "statement" {
-    for_each = var.application_account_numbers
+    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
     content {
       effect    = "Allow"
       actions   = ["kms:*"]
@@ -483,7 +483,7 @@ data "aws_iam_policy_document" "config_key" {
   }
 
   dynamic "statement" {
-    for_each = var.application_account_numbers
+    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
     content {
       effect    = "Allow"
       actions   = ["kms:*"]
@@ -505,4 +505,3 @@ data "aws_iam_policy_document" "config_key" {
     }
   }
 }
-

--- a/s3-accesslog.tf
+++ b/s3-accesslog.tf
@@ -54,7 +54,7 @@ data "aws_iam_policy_document" "s3_accesslogs_bucket_policy" {
     resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.resource_prefix}-${var.aws_region}-s3-accesslogs/*"]
   }
   dynamic "statement" {
-    for_each = var.application_account_numbers
+    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
     content {
       actions = ["s3:PutObject"]
       effect  = "Allow"

--- a/s3-cloudtrail.tf
+++ b/s3-cloudtrail.tf
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "log_bucket_policy" {
   }
 
   dynamic "statement" {
-    for_each = var.application_account_numbers
+    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
     content {
       #sid = "AgencyAWSCloudTrailWrite"
       actions = ["s3:PutObject"]
@@ -90,7 +90,7 @@ data "aws_iam_policy_document" "log_bucket_policy" {
   }
 
   dynamic "statement" {
-    for_each = var.application_account_numbers
+    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
     content {
       #sid = "AgencyAWSCloudTrailAclCheck"
       actions = ["s3:GetBucketAcl"]

--- a/s3-elb-accesslog.tf
+++ b/s3-elb-accesslog.tf
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "elb_accesslogs_bucket_policy" {
   }
 
   dynamic "statement" {
-    for_each = var.application_account_numbers
+    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
     content {
       actions = ["s3:PutObject"]
       effect  = "Allow"


### PR DESCRIPTION
Updated dynamic statements to be conditional based on if there are account numbers passed in the application_account_numbers var when calling the module. There was a KMS key creation error occurring when an empty list was passed (check Harrison's open issue). Tested this successfully in Coalfire GovCloud sandbox. Related PR also open for aws securitycore module to address bucket policy creation for s3-tstate.

<img width="1561" alt="Screenshot 2024-10-28 at 12 47 16 PM" src="https://github.com/user-attachments/assets/99defb73-18f7-4b44-9ba7-a0b1eac59e11">
<img width="1315" alt="Screenshot 2024-10-28 at 12 47 47 PM" src="https://github.com/user-attachments/assets/6bbf51d5-25fa-475c-811a-7aef8f7d4b12">
