### PR TITLE
Packer & EBS KMS IAM Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 *.tfstate
 *.tfstate.*
 
+# Ignore Infracost
+**.infracost
+
 # Crash log files
 crash.log
 

--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ module "account-setup" {
 | <a name="input_default_aws_region"></a> [default\_aws\_region](#input\_default\_aws\_region) | The default AWS region to create resources in | `string` | n/a | yes |
 | <a name="input_is_organization"></a> [is\_organization](#input\_is\_organization) | Whether or not to enable certain settings for AWS Organization | `bool` | `true` | no |
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | AWS Organization ID | `string` | `null` | no |
+| <a name="input_packer_additional_iam_principal_arns"></a> [packer\_additional\_iam\_principal\_arns](#input\_packer\_additional\_iam\_principal\_arns) | List of IAM Principal ARNs allowed to assume the Packer IAM Role | `list(string)` | `[]` | no |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | The prefix for resources | `string` | n/a | yes |
-| <a name="input_root_org_account_number"></a> [root\_org\_account\_number](#input\_root\_org\_account\_number) | The AWS account number for the Root Org Account | `string` | n/a | yes |
 
 ## Outputs
 
@@ -209,6 +209,8 @@ module "account-setup" {
 | <a name="output_ebs_kms_key_id"></a> [ebs\_kms\_key\_id](#output\_ebs\_kms\_key\_id) | n/a |
 | <a name="output_lambda_kms_key_arn"></a> [lambda\_kms\_key\_arn](#output\_lambda\_kms\_key\_arn) | n/a |
 | <a name="output_lambda_kms_key_id"></a> [lambda\_kms\_key\_id](#output\_lambda\_kms\_key\_id) | n/a |
+| <a name="output_packer_iam_role_arn"></a> [packer\_iam\_role\_arn](#output\_packer\_iam\_role\_arn) | n/a |
+| <a name="output_packer_iam_role_name"></a> [packer\_iam\_role\_name](#output\_packer\_iam\_role\_name) | n/a |
 | <a name="output_rds_kms_key_arn"></a> [rds\_kms\_key\_arn](#output\_rds\_kms\_key\_arn) | n/a |
 | <a name="output_rds_kms_key_id"></a> [rds\_kms\_key\_id](#output\_rds\_kms\_key\_id) | n/a |
 | <a name="output_s3_access_logs_arn"></a> [s3\_access\_logs\_arn](#output\_s3\_access\_logs\_arn) | n/a |

--- a/outputs.tf
+++ b/outputs.tf
@@ -149,3 +149,11 @@ output "s3_tstate_bucket_name" {
 output "dynamodb_table_name" {
   value = try(module.security-core[0].dynamodb_table_name, null)
 }
+
+output "packer_iam_role_arn" {
+  value = try(aws_iam_role.packer_role[0].arn, null)
+}
+
+output "packer_iam_role_name" {
+  value = try(aws_iam_role.packer_role[0].name, null)
+}

--- a/packer_iam.tf
+++ b/packer_iam.tf
@@ -82,7 +82,8 @@ data "aws_iam_policy_document" "packer_policy_document" {
       "ec2:RegisterImage",
       "ec2:RunInstances",
       "ec2:StopInstances",
-      "ec2:TerminateInstances"
+      "ec2:TerminateInstances",
+      "ec2:DescribeVpcs"
     ]
     resources = ["*"]
   }

--- a/packer_iam.tf
+++ b/packer_iam.tf
@@ -94,7 +94,8 @@ data "aws_iam_policy_document" "packer_policy_document" {
       "ec2:CreateLaunchTemplate",
       "ec2:DeleteLaunchTemplate",
       "ec2:CreateFleet",
-      "ec2:DescribeSpotPriceHistory"
+      "ec2:DescribeSpotPriceHistory",
+      "ec2:DescribeInstanceTypeOfferings"
     ]
     resources = ["*"]
   }

--- a/variables.tf
+++ b/variables.tf
@@ -173,3 +173,9 @@ variable "create_packer_iam" {
   type        = bool
   default     = false
 }
+
+variable "packer_additional_iam_principal_arns" {
+  description = "List of IAM Principal ARNs allowed to assume the Packer IAM Role"
+  type        = list(string)
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -19,11 +19,6 @@ variable "account_number" {
   type        = string
 }
 
-variable "root_org_account_number" {
-  description = "The AWS account number for the Root Org Account"
-  type        = string
-}
-
 variable "resource_prefix" {
   description = "The prefix for resources"
   type        = string


### PR DESCRIPTION
# Packer
- Added outputs "packer_iam_role_arn" and "packer_iam_role_nam" in case there are additional changes or attachments that need to occur outside of this pak itself.
  - Example use-case: I want to attach a "Base IAM Policy" that might have different settings depending on the deployment (permissions to get "svc_dj" secret, which might not exist in a non-AD deployment, or to retrieve and install a Private ACM Root CA certificate in a Packer AMI).
- Added optional variable list(string) "packer_additional_iam_principal_arns", which is a list of ARNs of principals allowed to assume the Packer role.
  - Example use-case: An unprivileged "packer" iam user is created to run Packer in automation (CI/CD).  The automation uses this IAM user who can only assume this one role, rather than my own user credentials that has AdministratorAccess privileges.
- Added IAM permissions to use Packer's native "Spot" instance arguments.  (this doesn't force you to use it, it only allows Packer to use Spot instances if desired)

# EBS KMS Key Policy
- Existing policy on the key is not appropriate for use in Auto-Scaling Groups.  If you attempt to launch ASG EC2 instances with this key, it will state "Termination Reason: Client.InvalidKMSKey,InvalidState: The KMS key provided is in an incorrect state"
- Updated the policy to reflect the latest AWS documentation: https://docs.aws.amazon.com/autoscaling/ec2/userguide/key-policy-requirements-EBS-encryption.html