### PR TITLE
Update s3 module version & remove lifecycle rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,15 +108,15 @@ module "account-setup" {
 | <a name="module_ebs_kms_key"></a> [ebs\_kms\_key](#module\_ebs\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
 | <a name="module_lambda_kms_key"></a> [lambda\_kms\_key](#module\_lambda\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
 | <a name="module_rds_kms_key"></a> [rds\_kms\_key](#module\_rds\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
-| <a name="module_s3-accesslogs"></a> [s3-accesslogs](#module\_s3-accesslogs) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.1 |
-| <a name="module_s3-backups"></a> [s3-backups](#module\_s3-backups) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.1 |
-| <a name="module_s3-cloudtrail"></a> [s3-cloudtrail](#module\_s3-cloudtrail) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.1 |
-| <a name="module_s3-config"></a> [s3-config](#module\_s3-config) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.1 |
-| <a name="module_s3-elb-accesslogs"></a> [s3-elb-accesslogs](#module\_s3-elb-accesslogs) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.1 |
-| <a name="module_s3-fedrampdoc"></a> [s3-fedrampdoc](#module\_s3-fedrampdoc) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.1 |
-| <a name="module_s3-installs"></a> [s3-installs](#module\_s3-installs) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.1 |
+| <a name="module_s3-accesslogs"></a> [s3-accesslogs](#module\_s3-accesslogs) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.4 |
+| <a name="module_s3-backups"></a> [s3-backups](#module\_s3-backups) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.4 |
+| <a name="module_s3-cloudtrail"></a> [s3-cloudtrail](#module\_s3-cloudtrail) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.4 |
+| <a name="module_s3-config"></a> [s3-config](#module\_s3-config) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.4 |
+| <a name="module_s3-elb-accesslogs"></a> [s3-elb-accesslogs](#module\_s3-elb-accesslogs) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.4 |
+| <a name="module_s3-fedrampdoc"></a> [s3-fedrampdoc](#module\_s3-fedrampdoc) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.4 |
+| <a name="module_s3-installs"></a> [s3-installs](#module\_s3-installs) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.4 |
 | <a name="module_s3_kms_key"></a> [s3\_kms\_key](#module\_s3\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
-| <a name="module_security-core"></a> [security-core](#module\_security-core) | github.com/Coalfire-CF/terraform-aws-securitycore | v0.0.19 |
+| <a name="module_security-core"></a> [security-core](#module\_security-core) | github.com/Coalfire-CF/terraform-aws-securitycore | v0.0.22 |
 | <a name="module_sm_kms_key"></a> [sm\_kms\_key](#module\_sm\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
 | <a name="module_sns_kms_key"></a> [sns\_kms\_key](#module\_sns\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
 

--- a/s3-accesslog.tf
+++ b/s3-accesslog.tf
@@ -2,7 +2,7 @@ module "s3-accesslogs" {
   count = var.create_s3_accesslogs_bucket ? 1 : 0
 
   #checkov:skip=CKV_AWS_145: "Ensure that S3 buckets are encrypted with KMS by default"
-  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.1"
+  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.4"
 
   name                    = "${var.resource_prefix}-${var.aws_region}-s3-accesslogs"
   attach_public_policy    = false

--- a/s3-aws-config.tf
+++ b/s3-aws-config.tf
@@ -1,7 +1,7 @@
 module "s3-config" {
   count = var.create_s3_config_bucket ? 1 : 0
 
-  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.1"
+  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.4"
 
   name                    = "${var.resource_prefix}-${var.aws_region}-config"
   kms_master_key_id       = module.s3_kms_key[0].kms_key_arn

--- a/s3-backups.tf
+++ b/s3-backups.tf
@@ -1,7 +1,7 @@
 module "s3-backups" {
   count = var.create_s3_backups_bucket ? 1 : 0
 
-  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.1"
+  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.4"
 
   name                    = "${var.resource_prefix}-${var.aws_region}-backups"
   kms_master_key_id       = module.s3_kms_key[0].kms_key_arn

--- a/s3-cloudtrail.tf
+++ b/s3-cloudtrail.tf
@@ -1,5 +1,5 @@
 module "s3-cloudtrail" {
-  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.1"
+  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.4"
 
   count = var.create_cloudtrail && var.default_aws_region == var.aws_region ? 1 : 0
 

--- a/s3-elb-accesslog.tf
+++ b/s3-elb-accesslog.tf
@@ -2,7 +2,7 @@ module "s3-elb-accesslogs" {
   count = var.create_s3_elb_accesslogs_bucket ? 1 : 0
 
   #checkov:skip=CKV_AWS_145: "Ensure that S3 buckets are encrypted with KMS by default"
-  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.1"
+  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.4"
 
   name                    = "${var.resource_prefix}-${var.aws_region}-elb-accesslogs"
   attach_public_policy    = false

--- a/s3-fedrampdoc.tf
+++ b/s3-fedrampdoc.tf
@@ -1,7 +1,7 @@
 module "s3-fedrampdoc" {
   count = var.create_s3_fedrampdoc_bucket ? 1 : 0
 
-  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.1"
+  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.4"
 
   name                    = "${var.resource_prefix}-${var.aws_region}-fedrampdoc"
   kms_master_key_id       = module.s3_kms_key[0].kms_key_arn
@@ -14,17 +14,4 @@ module "s3-fedrampdoc" {
   logging       = true
   target_bucket = module.s3-accesslogs[0].id
   target_prefix = "fedrampdoc/"
-
-  lifecycle_configuration_rules = [
-    {
-      id      = "default"
-      enabled = true
-
-      enable_glacier_transition            = false
-      enable_current_object_expiration     = false
-      enable_noncurrent_version_expiration = false
-
-      abort_incomplete_multipart_upload_days = 1
-    }
-  ]
 }

--- a/s3-installs.tf
+++ b/s3-installs.tf
@@ -1,7 +1,7 @@
 module "s3-installs" {
   count = var.create_s3_installs_bucket ? 1 : 0
 
-  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.1"
+  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.4"
 
   name                    = "${var.resource_prefix}-${var.aws_region}-installs"
   kms_master_key_id       = module.s3_kms_key[0].kms_key_arn
@@ -14,17 +14,4 @@ module "s3-installs" {
   logging       = true
   target_bucket = module.s3-accesslogs[0].id
   target_prefix = "installs/"
-
-  lifecycle_configuration_rules = [
-    {
-      id      = "default"
-      enabled = true
-
-      enable_glacier_transition            = false
-      enable_current_object_expiration     = false
-      enable_noncurrent_version_expiration = false
-
-      abort_incomplete_multipart_upload_days = 1
-    }
-  ]
 }

--- a/security-core.tf
+++ b/security-core.tf
@@ -1,8 +1,7 @@
 module "security-core" {
   count = var.create_security_core ? 1 : 0
 
-  #source = "github.com/Coalfire-CF/terraform-aws-securitycore?ref=fb87eca3e93fb973085b8146b53c9b89117c1378"
-  source = "github.com/Coalfire-CF/terraform-aws-securitycore?ref=v0.0.19"
+  source = "github.com/Coalfire-CF/terraform-aws-securitycore?ref=v0.0.22"
 
   application_account_numbers = var.application_account_numbers
   aws_region                  = var.aws_region


### PR DESCRIPTION
# s3
- Updates s3 pak module from v1.0.1 => v1.0.4.


# Security Core
- Updates security-core pak module from v0.0.19 => v0.0.22

This is primarily intended to remove the default s3 lifecycle rules, which can cause issues for certain objects (terraform state, app install files, etc.).

https://github.com/Coalfire-CF/terraform-aws-s3/pull/16