### PR TITLE
Creates role with auto scale svc policy attached

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,14 +131,17 @@ module "account-setup" {
 | [aws_iam_policy.packer_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy_attachment.cloudtrail-to-cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
 | [aws_iam_policy_attachment.packer_access_attach_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
+| [aws_iam_role.auto_scaling_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.cloudtrail-role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.packer_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.attach_autoscale_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kms_grant.packer_ebs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_grant) | resource |
 | [aws_kms_grant.packer_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_grant) | resource |
 | [aws_s3_bucket_policy.cloudtrail_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.config_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_elb_service_account.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_service_account) | data source |
+| [aws_iam_policy.autoScalePolicy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy_document.cloudtrail_assume_role_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cloudtrail_to_cloudwatch_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cloudwatch_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,25 @@
+data "aws_iam_policy" "autoScalePolicy" {
+  name = "AutoScalingServiceRolePolicy"
+}
+
+# Create the IAM role for Auto Scaling
+resource "aws_iam_role" "auto_scaling_role" {
+  name = "AutoScalingServiceRole"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect    = "Allow",
+        Principal = {
+          Service = "autoscaling.amazonaws.com"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "attach_autoscale_policy" {
+  role       = aws_iam_role.auto_scaling_role.name
+  policy_arn = data.aws_iam_policy.autoScalePolicy.arn
+}

--- a/iam.tf
+++ b/iam.tf
@@ -4,7 +4,7 @@ data "aws_iam_policy" "autoScalePolicy" {
 
 # Create the IAM role for Auto Scaling
 resource "aws_iam_role" "auto_scaling_role" {
-  name = "AutoScalingServiceRole"
+  name = "AWSServiceRoleForAutoScaling"
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [

--- a/kms.tf
+++ b/kms.tf
@@ -55,6 +55,8 @@ module "ebs_kms_key" {
   key_policy            = data.aws_iam_policy_document.ebs_key.json
   kms_key_resource_type = "ebs"
   resource_prefix       = var.resource_prefix
+
+  depends_on = [aws_iam_role_policy_attachment.attach_autoscale_policy]
 }
 
 data "aws_iam_policy_document" "ebs_key" {


### PR DESCRIPTION
EBS kms keys need a role with the AutoScalingServiceRolePolicy created before them, to avoid an IAM error. This code creates that role with that policy.