### PR TITLE
Feature updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ module "account-setup" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.5.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.10.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 
 ## Providers
@@ -165,15 +165,16 @@ module "account-setup" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_additional_kms_keys"></a> [additional\_kms\_keys](#module\_additional\_kms\_keys) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
-| <a name="module_backup_kms_key"></a> [backup\_kms\_key](#module\_backup\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
-| <a name="module_cloudwatch_kms_key"></a> [cloudwatch\_kms\_key](#module\_cloudwatch\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
-| <a name="module_config_kms_key"></a> [config\_kms\_key](#module\_config\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
-| <a name="module_dynamo_kms_key"></a> [dynamo\_kms\_key](#module\_dynamo\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
-| <a name="module_ebs_kms_key"></a> [ebs\_kms\_key](#module\_ebs\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
+| <a name="module_additional_kms_keys"></a> [additional\_kms\_keys](#module\_additional\_kms\_keys) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
+| <a name="module_backup_kms_key"></a> [backup\_kms\_key](#module\_backup\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
+| <a name="module_cloudwatch_kms_key"></a> [cloudwatch\_kms\_key](#module\_cloudwatch\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
+| <a name="module_config_kms_key"></a> [config\_kms\_key](#module\_config\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
+| <a name="module_dynamo_kms_key"></a> [dynamo\_kms\_key](#module\_dynamo\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
+| <a name="module_ebs_kms_key"></a> [ebs\_kms\_key](#module\_ebs\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
 | <a name="module_ecr_kms_key"></a> [ecr\_kms\_key](#module\_ecr\_kms\_key) | github.com/Coalfire-CF/ACE-AWS-KMS | v1.0.1 |
-| <a name="module_lambda_kms_key"></a> [lambda\_kms\_key](#module\_lambda\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
-| <a name="module_rds_kms_key"></a> [rds\_kms\_key](#module\_rds\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
+| <a name="module_lambda_kms_key"></a> [lambda\_kms\_key](#module\_lambda\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
+| <a name="module_nfw_kms_key"></a> [nfw\_kms\_key](#module\_nfw\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
+| <a name="module_rds_kms_key"></a> [rds\_kms\_key](#module\_rds\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
 | <a name="module_s3-accesslogs"></a> [s3-accesslogs](#module\_s3-accesslogs) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.4 |
 | <a name="module_s3-backups"></a> [s3-backups](#module\_s3-backups) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.4 |
 | <a name="module_s3-cloudtrail"></a> [s3-cloudtrail](#module\_s3-cloudtrail) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.4 |
@@ -181,10 +182,11 @@ module "account-setup" {
 | <a name="module_s3-elb-accesslogs"></a> [s3-elb-accesslogs](#module\_s3-elb-accesslogs) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.4 |
 | <a name="module_s3-fedrampdoc"></a> [s3-fedrampdoc](#module\_s3-fedrampdoc) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.4 |
 | <a name="module_s3-installs"></a> [s3-installs](#module\_s3-installs) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.4 |
-| <a name="module_s3_kms_key"></a> [s3\_kms\_key](#module\_s3\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
+| <a name="module_s3_kms_key"></a> [s3\_kms\_key](#module\_s3\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
 | <a name="module_security-core"></a> [security-core](#module\_security-core) | github.com/Coalfire-CF/terraform-aws-securitycore | v0.0.22 |
-| <a name="module_sm_kms_key"></a> [sm\_kms\_key](#module\_sm\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
-| <a name="module_sns_kms_key"></a> [sns\_kms\_key](#module\_sns\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v0.0.6 |
+| <a name="module_sm_kms_key"></a> [sm\_kms\_key](#module\_sm\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
+| <a name="module_sns_kms_key"></a> [sns\_kms\_key](#module\_sns\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
+| <a name="module_sqs_kms_key"></a> [sqs\_kms\_key](#module\_sqs\_kms\_key) | github.com/Coalfire-CF/ACE-AWS-KMS | v1.0.1 |
 
 ## Resources
 
@@ -213,6 +215,7 @@ module "account-setup" {
 | [aws_iam_policy.ecr_pull_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy.eks_cni_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy.eks_worker_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_iam_policy_document.additional_kms_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cloudtrail_assume_role_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cloudtrail_to_cloudwatch_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cloudwatch_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -220,7 +223,9 @@ module "account-setup" {
 | [aws_iam_policy_document.dynamo_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ebs_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecr_kms_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.eks_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.elb_accesslogs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.kms_base_and_sharing_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.log_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.packer_assume_role_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.packer_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -229,6 +234,7 @@ module "account-setup" {
 | [aws_iam_policy_document.s3_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.secrets_manager_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sns_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.sqs_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
@@ -237,7 +243,7 @@ module "account-setup" {
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_number"></a> [account\_number](#input\_account\_number) | The AWS account number resources are being deployed into | `string` | n/a | yes |
 | <a name="input_additional_kms_keys"></a> [additional\_kms\_keys](#input\_additional\_kms\_keys) | a list of maps of any additional KMS keys that need to be created | `list(map(string))` | `[]` | no |
-| <a name="input_application_account_numbers"></a> [application\_account\_numbers](#input\_application\_account\_numbers) | AWS account numbers for all application accounts that might need shared access to resources like KMS keys | `list(string)` | n/a | yes |
+| <a name="input_application_account_numbers"></a> [application\_account\_numbers](#input\_application\_account\_numbers) | AWS account numbers for all application accounts that might need shared access to resources like KMS keys | `list(string)` | `[]` | no |
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region to create resources in | `string` | n/a | yes |
 | <a name="input_cloudwatch_log_group_retention_in_days"></a> [cloudwatch\_log\_group\_retention\_in\_days](#input\_cloudwatch\_log\_group\_retention\_in\_days) | The number of days to retain Cloudwatch logs | `number` | `30` | no |
 | <a name="input_create_backup_kms_key"></a> [create\_backup\_kms\_key](#input\_create\_backup\_kms\_key) | create KMS key for AWS Backups | `bool` | `true` | no |
@@ -249,6 +255,7 @@ module "account-setup" {
 | <a name="input_create_ecr_kms_key"></a> [create\_ecr\_kms\_key](#input\_create\_ecr\_kms\_key) | create KMS key for ECR | `bool` | `true` | no |
 | <a name="input_create_eks_service_role"></a> [create\_eks\_service\_role](#input\_create\_eks\_service\_role) | Boolean to create an EKS Node Group service role | `bool` | `false` | no |
 | <a name="input_create_lambda_kms_key"></a> [create\_lambda\_kms\_key](#input\_create\_lambda\_kms\_key) | create KMS key for lambda | `bool` | `true` | no |
+| <a name="input_create_nfw_kms_key"></a> [create\_nfw\_kms\_key](#input\_create\_nfw\_kms\_key) | create KMS key for NFW | `bool` | `true` | no |
 | <a name="input_create_packer_iam"></a> [create\_packer\_iam](#input\_create\_packer\_iam) | Whether or not to create Packer IAM resources | `bool` | `false` | no |
 | <a name="input_create_rds_kms_key"></a> [create\_rds\_kms\_key](#input\_create\_rds\_kms\_key) | create KMS key for rds | `bool` | `true` | no |
 | <a name="input_create_s3_accesslogs_bucket"></a> [create\_s3\_accesslogs\_bucket](#input\_create\_s3\_accesslogs\_bucket) | Create S3 Access Logs Bucket | `bool` | `true` | no |
@@ -261,12 +268,16 @@ module "account-setup" {
 | <a name="input_create_security_core"></a> [create\_security\_core](#input\_create\_security\_core) | Whether or not to create Security Core resources | `bool` | `false` | no |
 | <a name="input_create_sm_kms_key"></a> [create\_sm\_kms\_key](#input\_create\_sm\_kms\_key) | create KMS key for secrets manager | `bool` | `true` | no |
 | <a name="input_create_sns_kms_key"></a> [create\_sns\_kms\_key](#input\_create\_sns\_kms\_key) | create KMS key for SNS | `bool` | `true` | no |
+| <a name="input_create_sqs_kms_key"></a> [create\_sqs\_kms\_key](#input\_create\_sqs\_kms\_key) | create KMS key for SQS | `bool` | `true` | no |
 | <a name="input_default_aws_region"></a> [default\_aws\_region](#input\_default\_aws\_region) | The default AWS region to create resources in | `string` | n/a | yes |
 | <a name="input_is_organization"></a> [is\_organization](#input\_is\_organization) | Whether or not to enable certain settings for AWS Organization | `bool` | `true` | no |
+| <a name="input_kms_multi_region"></a> [kms\_multi\_region](#input\_kms\_multi\_region) | Indicates whether the KMS key is a multi-Region (true) or regional (false) key. | `bool` | `false` | no |
 | <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | AWS Organization ID | `string` | `null` | no |
 | <a name="input_packer_additional_iam_principal_arns"></a> [packer\_additional\_iam\_principal\_arns](#input\_packer\_additional\_iam\_principal\_arns) | List of IAM Principal ARNs allowed to assume the Packer IAM Role | `list(string)` | `[]` | no |
-| <a name="input_profile"></a> [profile](#input\_profile) | n/a | `any` | n/a | yes |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | The prefix for resources | `string` | n/a | yes |
+| <a name="input_s3_backup_policy"></a> [s3\_backup\_policy](#input\_s3\_backup\_policy) | S3 backup policy to use for S3 buckets in conjunction with AWS Backups, should match an existing policy | `string` | `""` | no |
+| <a name="input_s3_backup_settings"></a> [s3\_backup\_settings](#input\_s3\_backup\_settings) | Map of S3 bucket types to their backup settings | <pre>map(object({<br/>    enable_backup = bool<br/>  }))</pre> | <pre>{<br/>  "accesslogs": {<br/>    "enable_backup": false<br/>  },<br/>  "backups": {<br/>    "enable_backup": true<br/>  },<br/>  "cloudtrail": {<br/>    "enable_backup": false<br/>  },<br/>  "config": {<br/>    "enable_backup": true<br/>  },<br/>  "elb-accesslogs": {<br/>    "enable_backup": false<br/>  },<br/>  "fedrampdoc": {<br/>    "enable_backup": true<br/>  },<br/>  "installs": {<br/>    "enable_backup": true<br/>  }<br/>}</pre> | no |
+| <a name="input_s3_tags"></a> [s3\_tags](#input\_s3\_tags) | Tags to be applied to S3 buckets | `map(any)` | `{}` | no |
 
 ## Outputs
 
@@ -291,6 +302,8 @@ module "account-setup" {
 | <a name="output_eks_node_role_name"></a> [eks\_node\_role\_name](#output\_eks\_node\_role\_name) | n/a |
 | <a name="output_lambda_kms_key_arn"></a> [lambda\_kms\_key\_arn](#output\_lambda\_kms\_key\_arn) | n/a |
 | <a name="output_lambda_kms_key_id"></a> [lambda\_kms\_key\_id](#output\_lambda\_kms\_key\_id) | n/a |
+| <a name="output_nfw_kms_key_arn"></a> [nfw\_kms\_key\_arn](#output\_nfw\_kms\_key\_arn) | n/a |
+| <a name="output_nfw_kms_key_id"></a> [nfw\_kms\_key\_id](#output\_nfw\_kms\_key\_id) | n/a |
 | <a name="output_packer_iam_role_arn"></a> [packer\_iam\_role\_arn](#output\_packer\_iam\_role\_arn) | n/a |
 | <a name="output_packer_iam_role_name"></a> [packer\_iam\_role\_name](#output\_packer\_iam\_role\_name) | n/a |
 | <a name="output_rds_kms_key_arn"></a> [rds\_kms\_key\_arn](#output\_rds\_kms\_key\_arn) | n/a |
@@ -316,6 +329,8 @@ module "account-setup" {
 | <a name="output_sm_kms_key_id"></a> [sm\_kms\_key\_id](#output\_sm\_kms\_key\_id) | n/a |
 | <a name="output_sns_kms_key_arn"></a> [sns\_kms\_key\_arn](#output\_sns\_kms\_key\_arn) | n/a |
 | <a name="output_sns_kms_key_id"></a> [sns\_kms\_key\_id](#output\_sns\_kms\_key\_id) | n/a |
+| <a name="output_sqs_kms_key_arn"></a> [sqs\_kms\_key\_arn](#output\_sqs\_kms\_key\_arn) | n/a |
+| <a name="output_sqs_kms_key_id"></a> [sqs\_kms\_key\_id](#output\_sqs\_kms\_key\_id) | n/a |
 <!-- END_TF_DOCS -->
 
 ## Contributing

--- a/iam.tf
+++ b/iam.tf
@@ -3,21 +3,21 @@ resource "aws_iam_service_linked_role" "autoscale" {
 }
 
 resource "aws_iam_role" "eks_node_role" {
-  count      = var.create_eks_service_role ? 1 : 0
-  name = "EKSNodeRole"
+  count = var.create_eks_service_role ? 1 : 0
+  name  = "EKSNodeRole"
 
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Effect = "Allow",
-        Principal = {
-          Service = "ec2.amazonaws.com"
-        }
-        Action = "sts:AssumeRole"
-      }
-    ]
-  })
+  assume_role_policy = data.aws_iam_policy_document.eks_assume_role_policy.json
+}
+
+data "aws_iam_policy_document" "eks_assume_role_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
 }
 
 data "aws_iam_policy" "eks_worker_policy" {

--- a/kms.tf
+++ b/kms.tf
@@ -340,7 +340,7 @@ module "cloudwatch_kms_key" {
 
   kms_key_resource_type = "cloudwatch"
   resource_prefix       = var.resource_prefix
-  key_policy            = data.aws_iam_policy_document.cloudwatch_key.json
+  key_policy            = data.aws_iam_policy_document.cloudwatch_key[0].json
   multi_region          = var.kms_multi_region
 }
 

--- a/kms.tf
+++ b/kms.tf
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "kms_base_and_sharing_permissions" {
 
   # Sharing KMS Key using AWS Organization ID
   dynamic "statement" {
-    for_each = var.is_organization && length(var.organization_id) > 0 ? [1] : []
+    for_each = var.is_organization && var.organization_id != null ? [1] : []
     content {
       effect    = "Allow"
       actions   = ["kms:*"]

--- a/kms.tf
+++ b/kms.tf
@@ -1,14 +1,6 @@
-module "dynamo_kms_key" {
-  count = var.create_dynamo_kms_key ? 1 : 0
-
-  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v0.0.6"
-
-  key_policy            = data.aws_iam_policy_document.dynamo_key.json
-  kms_key_resource_type = "dynamodb"
-  resource_prefix       = var.resource_prefix
-}
-
-data "aws_iam_policy_document" "dynamo_key" {
+# To reduce code deduplication, we'll define a common policy used by all KMS keys and merge them using "source_policy_documents"
+# This also makes it easier to parse the policy that is directly related to a service key.
+data "aws_iam_policy_document" "kms_base_and_sharing_permissions" {
   #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
   #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
   # https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html
@@ -22,6 +14,72 @@ data "aws_iam_policy_document" "dynamo_key" {
       identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.account_number}:root"]
     }
   }
+
+  # Sharing KMS Key using Account IDs
+  dynamic "statement" {
+    for_each = !var.is_organization ? toset(var.application_account_numbers) : []
+    content {
+      effect = "Allow"
+      actions = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey",
+        "kms:CreateGrant",
+        "kms:ListGrants",
+        "kms:RevokeGrant"
+      ]
+      resources = ["*"]
+      principals {
+        type        = "AWS"
+        identifiers = ["arn:${data.aws_partition.current.partition}:iam::${statement.value}:root"]
+      }
+    }
+  }
+
+  # Sharing KMS Key using AWS Organization ID
+  dynamic "statement" {
+    for_each = var.is_organization && length(var.organization_id) > 0 ? [1] : []
+    content {
+      effect    = "Allow"
+      actions   = ["kms:*"]
+      resources = ["*"]
+      principals {
+        type        = "AWS"
+        identifiers = ["*"]
+      }
+      condition {
+        test     = "StringEquals"
+        variable = "aws:PrincipalOrgID"
+        values   = [var.organization_id]
+      }
+    }
+  }
+}
+
+module "dynamo_kms_key" {
+  count = var.create_dynamo_kms_key ? 1 : 0
+
+  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v1.0.1"
+
+  key_policy            = data.aws_iam_policy_document.dynamo_key[0].json
+  kms_key_resource_type = "dynamodb"
+  resource_prefix       = var.resource_prefix
+  multi_region          = var.kms_multi_region
+}
+
+data "aws_iam_policy_document" "dynamo_key" {
+  count = var.create_dynamo_kms_key ? 1 : 0
+
+  #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
+  #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
+  # https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html
+
+  source_policy_documents = [
+    data.aws_iam_policy_document.kms_base_and_sharing_permissions.json
+  ]
+
   statement {
     effect = "Allow"
     actions = [
@@ -50,53 +108,26 @@ data "aws_iam_policy_document" "dynamo_key" {
 module "ebs_kms_key" {
   count = var.create_ebs_kms_key ? 1 : 0
 
-  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v0.0.6"
+  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v1.0.1"
 
-  key_policy            = data.aws_iam_policy_document.ebs_key.json
+  key_policy            = data.aws_iam_policy_document.ebs_key[0].json
   kms_key_resource_type = "ebs"
   resource_prefix       = var.resource_prefix
+  multi_region          = var.kms_multi_region
 
   depends_on = [aws_iam_service_linked_role.autoscale]
 }
 
 data "aws_iam_policy_document" "ebs_key" {
+  count = var.create_ebs_kms_key ? 1 : 0
+
   #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
   #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
   # https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html
 
-  statement {
-    effect    = "Allow"
-    actions   = ["kms:*"]
-    resources = ["*"]
-    principals {
-      type = "AWS"
-      identifiers = [
-        "arn:${data.aws_partition.current.partition}:iam::${var.account_number}:root"
-      ]
-    }
-  }
-
-  dynamic "statement" {
-    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
-    content {
-      effect = "Allow"
-      actions = [
-        "kms:Encrypt",
-        "kms:Decrypt",
-        "kms:ReEncrypt*",
-        "kms:GenerateDataKey*",
-        "kms:DescribeKey",
-        "kms:CreateGrant",
-        "kms:ListGrants",
-        "kms:RevokeGrant"
-      ]
-      resources = ["*"]
-      principals {
-        type        = "AWS"
-        identifiers = ["arn:${data.aws_partition.current.partition}:iam::${statement.value}:root"]
-      }
-    }
-  }
+  source_policy_documents = [
+    data.aws_iam_policy_document.kms_base_and_sharing_permissions.json
+  ]
 
   ################################################################################
   # Auto-Scaling Group
@@ -140,40 +171,24 @@ data "aws_iam_policy_document" "ebs_key" {
 module "s3_kms_key" {
   count = var.create_s3_kms_key ? 1 : 0
 
-  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v0.0.6"
+  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v1.0.1"
 
-  key_policy            = data.aws_iam_policy_document.s3_key.json
+  key_policy            = data.aws_iam_policy_document.s3_key[0].json
   kms_key_resource_type = "s3"
   resource_prefix       = var.resource_prefix
+  multi_region          = var.kms_multi_region
 }
 
 data "aws_iam_policy_document" "s3_key" {
+  count = var.create_s3_kms_key ? 1 : 0
+
   #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
   #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
   # https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html
 
-  dynamic "statement" {
-    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
-    content {
-      effect    = "Allow"
-      actions   = ["kms:*"]
-      resources = ["*"]
-      principals {
-        identifiers = ["arn:${data.aws_partition.current.partition}:iam::${statement.value}:root"]
-        type        = "AWS"
-      }
-    }
-  }
-
-  statement {
-    effect    = "Allow"
-    actions   = ["kms:*"]
-    resources = ["*"]
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.account_number}:root"]
-    }
-  }
+  source_policy_documents = [
+    data.aws_iam_policy_document.kms_base_and_sharing_permissions.json
+  ]
 
   statement {
     effect = "Allow"
@@ -226,7 +241,7 @@ data "aws_iam_policy_document" "s3_key" {
   }
 
   dynamic "statement" {
-    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
+    for_each = toset(var.application_account_numbers)
     content {
       effect    = "Allow"
       actions   = ["kms:GenerateDataKey*"]
@@ -247,159 +262,98 @@ data "aws_iam_policy_document" "s3_key" {
 module "sns_kms_key" {
   count = var.create_sns_kms_key ? 1 : 0
 
-  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v0.0.6"
+  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v1.0.1"
 
-  key_policy            = data.aws_iam_policy_document.sns_key.json
+  key_policy            = data.aws_iam_policy_document.sns_key[0].json
   kms_key_resource_type = "sns"
   resource_prefix       = var.resource_prefix
+  multi_region          = var.kms_multi_region
 }
 
 data "aws_iam_policy_document" "sns_key" {
+  count = var.create_sns_kms_key ? 1 : 0
+
   #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
   #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
   # https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html
 
-  statement {
-    effect    = "Allow"
-    actions   = ["kms:*"]
-    resources = ["*"]
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.account_number}:root"]
-    }
-  }
-  dynamic "statement" {
-    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
-    content {
-      effect = "Allow"
-      actions = [
-        "kms:Encrypt",
-        "kms:Decrypt",
-        "kms:ReEncrypt*",
-        "kms:GenerateDataKey*",
-        "kms:DescribeKey",
-        "kms:CreateGrant",
-        "kms:ListGrants",
-        "kms:RevokeGrant"
-      ]
-      resources = ["*"]
-      principals {
-        type        = "AWS"
-        identifiers = ["arn:${data.aws_partition.current.partition}:iam::${statement.value}:root"]
-      }
-    }
-  }
+  source_policy_documents = [
+    data.aws_iam_policy_document.kms_base_and_sharing_permissions.json
+  ]
 }
 
 module "sm_kms_key" {
   count  = var.create_sm_kms_key ? 1 : 0
-  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v0.0.6"
+  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v1.0.1"
 
-  key_policy            = data.aws_iam_policy_document.secrets_manager_key.json
+  key_policy            = data.aws_iam_policy_document.secrets_manager_key[0].json
   kms_key_resource_type = "sm"
   resource_prefix       = var.resource_prefix
+  multi_region          = var.kms_multi_region
 }
 
 data "aws_iam_policy_document" "secrets_manager_key" {
+  count = var.create_sm_kms_key ? 1 : 0
+
   #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
   #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
   # https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html
 
-  dynamic "statement" {
-    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
-    content {
-      effect    = "Allow"
-      actions   = ["kms:*"]
-      resources = ["*"]
-      principals {
-        identifiers = ["arn:${data.aws_partition.current.partition}:iam::${statement.value}:root"]
-        type        = "AWS"
-      }
-    }
-  }
-
-  statement {
-    sid     = "Enable MGMT IAM User Permissions"
-    effect  = "Allow"
-    actions = ["kms:*"]
-    principals {
-      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.account_number}:root"]
-      type        = "AWS"
-    }
-    resources = ["*"]
-  }
+  source_policy_documents = [
+    data.aws_iam_policy_document.kms_base_and_sharing_permissions.json
+  ]
 }
 
 module "backup_kms_key" {
   count  = var.create_backup_kms_key ? 1 : 0
-  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v0.0.6"
+  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v1.0.1"
 
-  key_policy            = data.aws_iam_policy_document.s3_key.json
+  key_policy            = data.aws_iam_policy_document.s3_key[0].json
   kms_key_resource_type = "backup"
   resource_prefix       = var.resource_prefix
+  multi_region          = var.kms_multi_region
 }
 
 module "lambda_kms_key" {
   count  = var.create_lambda_kms_key ? 1 : 0
-  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v0.0.6"
+  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v1.0.1"
 
   kms_key_resource_type = "lambda"
+  key_policy            = data.aws_iam_policy_document.kms_base_and_sharing_permissions.json
   resource_prefix       = var.resource_prefix
+  multi_region          = var.kms_multi_region
 }
 
 module "rds_kms_key" {
   count  = var.create_rds_kms_key ? 1 : 0
-  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v0.0.6"
+  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v1.0.1"
 
   kms_key_resource_type = "rds"
+  key_policy            = data.aws_iam_policy_document.kms_base_and_sharing_permissions.json
   resource_prefix       = var.resource_prefix
+  multi_region          = var.kms_multi_region
 }
 
 module "cloudwatch_kms_key" {
   count  = var.create_cloudwatch_kms_key ? 1 : 0
-  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v0.0.6"
+  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v1.0.1"
 
   kms_key_resource_type = "cloudwatch"
   resource_prefix       = var.resource_prefix
   key_policy            = data.aws_iam_policy_document.cloudwatch_key.json
-}
-
-module "additional_kms_keys" {
-  source   = "github.com/Coalfire-CF/terraform-aws-kms?ref=v0.0.6"
-  for_each = { for key in var.additional_kms_keys : key.name => key }
-
-  key_policy            = each.value.policy
-  kms_key_resource_type = each.value.name
-  resource_prefix       = var.resource_prefix
+  multi_region          = var.kms_multi_region
 }
 
 data "aws_iam_policy_document" "cloudwatch_key" {
+  var.create_cloudwatch_kms_key ? 1 : 0
+
   #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
   #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
   # https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html
 
-  dynamic "statement" {
-    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
-    content {
-      effect    = "Allow"
-      actions   = ["kms:*"]
-      resources = ["*"]
-      principals {
-        identifiers = ["arn:${data.aws_partition.current.partition}:iam::${statement.value}:root"]
-        type        = "AWS"
-      }
-    }
-  }
-
-  statement {
-    effect    = "Allow"
-    actions   = ["kms:*"]
-    resources = ["*"]
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.account_number}:root"]
-    }
-  }
+  source_policy_documents = [
+    data.aws_iam_policy_document.kms_base_and_sharing_permissions.json
+  ]
 
   statement {
     effect = "Allow"
@@ -411,7 +365,6 @@ data "aws_iam_policy_document" "cloudwatch_key" {
       "kms:DescribeKey",
     ]
     resources = ["*"]
-
     principals {
       type        = "Service"
       identifiers = ["delivery.logs.amazonaws.com"]
@@ -428,7 +381,6 @@ data "aws_iam_policy_document" "cloudwatch_key" {
       "kms:DescribeKey",
     ]
     resources = ["*"]
-
     principals {
       type        = "Service"
       identifiers = ["logs.${var.default_aws_region}.amazonaws.com"]
@@ -452,7 +404,7 @@ data "aws_iam_policy_document" "cloudwatch_key" {
   }
 
   dynamic "statement" {
-    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
+    for_each = toset(var.application_account_numbers)
     content {
       effect    = "Allow"
       actions   = ["kms:GenerateDataKey*"]
@@ -470,88 +422,115 @@ data "aws_iam_policy_document" "cloudwatch_key" {
   }
 }
 
-module "config_kms_key" {
-  count  = var.create_config_kms_key ? 1 : 0
-  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v0.0.6"
+module "additional_kms_keys" {
+  source   = "github.com/Coalfire-CF/terraform-aws-kms?ref=v1.0.1"
+  for_each = { for key in var.additional_kms_keys : key.name => key }
 
-  kms_key_resource_type = "config"
+  key_policy            = data.aws_iam_policy_document.additional_kms_keys[each.key].json
+  kms_key_resource_type = each.value.name
   resource_prefix       = var.resource_prefix
-  key_policy            = data.aws_iam_policy_document.config_key.json
+  multi_region          = var.kms_multi_region
 }
 
-data "aws_iam_policy_document" "config_key" {
+data "aws_iam_policy_document" "additional_kms_keys" {
+  # This just merges the provided key policies with the base/sharing policy
+  for_each = { for key in var.additional_kms_keys : key.name => key }
+
   #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
   #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
   # https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html
 
-  dynamic "statement" {
-    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
-    content {
-      effect    = "Allow"
-      actions   = ["kms:*"]
-      resources = ["*"]
-      principals {
-        type        = "Service"
-        identifiers = ["config.amazonaws.com"]
-      }
-    }
-  }
+  source_policy_documents = [
+    data.aws_iam_policy_document.kms_base_and_sharing_permissions.json,
+    each.value.policy
+  ]
+}
 
-  dynamic "statement" {
-    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
-    content {
-      effect    = "Allow"
-      actions   = ["kms:*"]
-      resources = ["*"]
-      principals {
-        identifiers = ["arn:${data.aws_partition.current.partition}:iam::${statement.value}:root"]
-        type        = "AWS"
-      }
-    }
-  }
+module "config_kms_key" {
+  count  = var.create_config_kms_key ? 1 : 0
+  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v1.0.1"
+
+  kms_key_resource_type = "config"
+  resource_prefix       = var.resource_prefix
+  key_policy            = data.aws_iam_policy_document.config_key[0].json
+  multi_region          = var.kms_multi_region
+}
+
+data "aws_iam_policy_document" "config_key" {
+  count = var.create_config_kms_key ? 1 : 0
+
+  #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
+  #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
+  # https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html
+
+  source_policy_documents = [
+    data.aws_iam_policy_document.kms_base_and_sharing_permissions.json
+  ]
 
   statement {
     effect    = "Allow"
     actions   = ["kms:*"]
     resources = ["*"]
     principals {
-      type        = "AWS"
-      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.account_number}:root"]
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
     }
   }
 }
 
 module "ecr_kms_key" {
-  count  = var.create_ecr_kms_key ? 1 : 0
+  count = var.create_ecr_kms_key ? 1 : 0
 
-  source                    = "github.com/Coalfire-CF/ACE-AWS-KMS?ref=v1.0.1"
-  resource_prefix = var.resource_prefix
+  source                = "github.com/Coalfire-CF/ACE-AWS-KMS?ref=v1.0.1"
+  resource_prefix       = var.resource_prefix
   kms_key_resource_type = "ecr"
-  key_policy = data.aws_iam_policy_document.ecr_kms_policy.json
+  key_policy            = data.aws_iam_policy_document.ecr_kms_policy[0].json
+  multi_region          = var.kms_multi_region
 }
 
 data "aws_iam_policy_document" "ecr_kms_policy" {
-  statement {
-    sid       = "source-account-full-access"
-    effect    = "Allow"
-    actions   = ["kms:*"]
-    resources = ["*"]
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${var.account_number}:root"]
-    }
-  }
+  count = var.create_ecr_kms_key ? 1 : 0
 
-   dynamic "statement" {
-    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
-    content {
-      effect    = "Allow"
-      actions   = ["kms:*"]
-      resources = ["*"]
-      principals {
-        identifiers = ["arn:${data.aws_partition.current.partition}:iam::${statement.value}:root"]
-        type        = "AWS"
-      }
+  #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
+  #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
+  # https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html
+
+  source_policy_documents = [
+    data.aws_iam_policy_document.kms_base_and_sharing_permissions.json
+  ]
+}
+
+module "sqs_kms_key" {
+  count = var.create_sqs_kms_key ? 1 : 0
+
+  source                = "github.com/Coalfire-CF/ACE-AWS-KMS?ref=v1.0.1"
+  resource_prefix       = var.resource_prefix
+  kms_key_resource_type = "sqs"
+  key_policy            = data.aws_iam_policy_document.sqs_kms_policy[0].json
+  multi_region          = var.kms_multi_region
+}
+
+data "aws_iam_policy_document" "sqs_key_policy" {
+  count = var.create_sqs_kms_key ? 1 : 0
+
+  #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
+  #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
+  # https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html
+
+  source_policy_documents = [
+    data.aws_iam_policy_document.kms_base_and_sharing_permissions.json
+  ]
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
     }
-  }     
+    resources = ["*"]
+  }
 }

--- a/kms.tf
+++ b/kms.tf
@@ -534,3 +534,14 @@ data "aws_iam_policy_document" "sqs_key_policy" {
     resources = ["*"]
   }
 }
+
+module "nfw_kms_key" {
+  count = var.create_nfw_kms_key ? 1 : 0
+
+  source = "github.com/Coalfire-CF/terraform-aws-kms?ref=v1.0.1"
+
+  key_policy            = data.aws_iam_policy_document.kms_base_and_sharing_permissions.json
+  kms_key_resource_type = "nfw"
+  resource_prefix       = var.resource_prefix
+  multi_region          = var.kms_multi_region
+}

--- a/kms.tf
+++ b/kms.tf
@@ -345,7 +345,7 @@ module "cloudwatch_kms_key" {
 }
 
 data "aws_iam_policy_document" "cloudwatch_key" {
-  var.create_cloudwatch_kms_key ? 1 : 0
+  count = var.create_cloudwatch_kms_key ? 1 : 0
 
   #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
   #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
@@ -506,11 +506,11 @@ module "sqs_kms_key" {
   source                = "github.com/Coalfire-CF/ACE-AWS-KMS?ref=v1.0.1"
   resource_prefix       = var.resource_prefix
   kms_key_resource_type = "sqs"
-  key_policy            = data.aws_iam_policy_document.sqs_kms_policy[0].json
+  key_policy            = data.aws_iam_policy_document.sqs_key[0].json
   multi_region          = var.kms_multi_region
 }
 
-data "aws_iam_policy_document" "sqs_key_policy" {
+data "aws_iam_policy_document" "sqs_key" {
   count = var.create_sqs_kms_key ? 1 : 0
 
   #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"

--- a/outputs.tf
+++ b/outputs.tf
@@ -142,6 +142,14 @@ output "ecr_kms_key_id" {
   value = try(module.ecr_kms_key[0].kms_key_id, null)
 }
 
+output "sqs_kms_key_arn" {
+  value = try(module.sqs_kms_key[0].kms_key_arn, null)
+}
+
+output "sqs_kms_key_id" {
+  value = try(module.ecr_kms_key[0].sqs_key_id, null)
+}
+
 output "additional_kms_key_arns" {
   value = { for k, v in module.additional_kms_keys : k => v.kms_key_arn }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -142,12 +142,20 @@ output "ecr_kms_key_id" {
   value = try(module.ecr_kms_key[0].kms_key_id, null)
 }
 
+output "nfw_kms_key_arn" {
+  value = try(module.nfw_kms_key[0].kms_key_arn, null)
+}
+
+output "nfw_kms_key_id" {
+  value = try(module.nfw_kms_key[0].kms_key_id, null)
+}
+
 output "sqs_kms_key_arn" {
   value = try(module.sqs_kms_key[0].kms_key_arn, null)
 }
 
 output "sqs_kms_key_id" {
-  value = try(module.ecr_kms_key[0].sqs_key_id, null)
+  value = try(module.sqs_kms_key[0].kms_key_id, null)
 }
 
 output "additional_kms_key_arns" {

--- a/packer_iam.tf
+++ b/packer_iam.tf
@@ -1,4 +1,6 @@
 data "aws_iam_policy_document" "packer_assume_role_policy_document" {
+  count = var.create_packer_iam ? 1 : 0
+
   statement {
     sid     = "PackerAssumeRoleAdministrator"
     effect  = "Allow"
@@ -37,10 +39,12 @@ resource "aws_iam_role" "packer_role" {
 
   name = "${var.resource_prefix}_packer_role"
 
-  assume_role_policy = data.aws_iam_policy_document.packer_assume_role_policy_document.json
+  assume_role_policy = data.aws_iam_policy_document.packer_assume_role_policy_document[0].json
 }
 
 data "aws_iam_policy_document" "packer_policy_document" {
+  count = var.create_packer_iam ? 1 : 0
+
   #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
   #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
   #checkov:skip=CKV_AWS_110: "Ensure IAM policies does not allow privilege escalation"
@@ -146,7 +150,7 @@ resource "aws_iam_policy" "packer_policy" {
 
   name        = "${var.resource_prefix}_packer_policy"
   description = "General Policy which will attach to ec2 for packer to give access to ec2,s3"
-  policy      = data.aws_iam_policy_document.packer_policy_document.json
+  policy      = data.aws_iam_policy_document.packer_policy_document[0].json
 }
 
 resource "aws_iam_policy_attachment" "packer_access_attach_policy" {

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">=1.5.0"
+  required_version = ">=1.10.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/s3-aws-config.tf
+++ b/s3-aws-config.tf
@@ -14,6 +14,14 @@ module "s3-config" {
   logging       = true
   target_bucket = module.s3-accesslogs[0].id
   target_prefix = "config/"
+
+  # Tags
+  tags = merge(
+    try(var.s3_backup_settings["config"].enable_backup, false) && length(var.s3_backup_policy) > 0 ? {
+      backup_policy = var.s3_backup_policy
+    } : {},
+    var.s3_tags
+  )
 }
 
 resource "aws_s3_bucket_policy" "config_bucket_policy" {
@@ -26,40 +34,47 @@ resource "aws_s3_bucket_policy" "config_bucket_policy" {
 data "aws_iam_policy_document" "s3_config_bucket_policy_doc" {
   count = var.create_s3_config_bucket && var.default_aws_region == var.aws_region ? 1 : 0
 
-  dynamic "statement" {
-    for_each = var.application_account_numbers
-    content {
-      effect  = "Allow"
-      actions = ["s3:GetBucketAcl", "s3:ListBucket", "s3:PutObject*"]
-      resources = [
-        module.s3-config[0].arn
-      ]
-      principals {
-        type        = "Service"
-        identifiers = ["config.amazonaws.com"]
-      }
+  # https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-policy.html#granting-access-in-another-account
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetBucketAcl",
+      "s3:ListBucket"
+    ]
+    resources = [
+      module.s3-config[0].arn
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = concat([var.account_number], var.application_account_numbers)
     }
   }
-  dynamic "statement" {
-    for_each = var.application_account_numbers
-    content {
-      effect  = "Allow"
-      actions = ["s3:PutObject*"]
-      resources = [
-        module.s3-config[0].arn,
-        "${module.s3-config[0].arn}/*"
-      ]
-      principals {
-        type        = "Service"
-        identifiers = ["config.amazonaws.com"]
-      }
-      condition {
-        test     = "StringEquals"
-        variable = "s3:x-amz-acl"
-        values   = ["bucket-owner-full-control"]
-      }
+
+  statement {
+    effect  = "Allow"
+    actions = ["s3:PutObject"]
+    resources = [
+      "${module.s3-config[0].arn}/*"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
     }
-
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = concat([var.account_number], var.application_account_numbers)
+    }
   }
-
 }

--- a/s3-aws-config.tf
+++ b/s3-aws-config.tf
@@ -57,26 +57,26 @@ data "aws_iam_policy_document" "s3_config_bucket_policy_doc" {
     }
   }
 
-  statement{
-      effect  = "Allow"
-      actions = ["s3:PutObject"]
-      resources = [
-        "${module.s3-config[0].arn}/*"
-      ]
-      principals {
-        type        = "Service"
-        identifiers = ["config.amazonaws.com"]
-      }
-      condition {
-        test     = "StringEquals"
-        variable = "s3:x-amz-acl"
-        values   = ["bucket-owner-full-control"]
-      }
-      condition {
-        test     = "StringEquals"
-        variable = "aws:SourceAccount"
-        values   = [var.account_number]
-      }
+  statement {
+    effect  = "Allow"
+    actions = ["s3:PutObject"]
+    resources = [
+      "${module.s3-config[0].arn}/*"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [var.account_number]
+    }
   }
 
   # Sharing with AWS Account IDs

--- a/s3-backups.tf
+++ b/s3-backups.tf
@@ -14,4 +14,12 @@ module "s3-backups" {
   logging       = true
   target_bucket = module.s3-accesslogs[0].id
   target_prefix = "backups/"
+
+  # Tags
+  tags = merge(
+    try(var.s3_backup_settings["backups"].enable_backup, false) && length(var.s3_backup_policy) > 0 ? {
+      backup_policy = var.s3_backup_policy
+    } : {},
+    var.s3_tags
+  )
 }

--- a/s3-cloudtrail.tf
+++ b/s3-cloudtrail.tf
@@ -52,12 +52,12 @@ data "aws_iam_policy_document" "log_bucket_policy" {
   }
 
   statement {
-    sid = "AWSCloudTrailAclCheck"
+    sid     = "AWSCloudTrailAclCheck"
     actions = ["s3:GetBucketAcl"]
-    effect = "Allow"
+    effect  = "Allow"
     principals {
       identifiers = ["cloudtrail.amazonaws.com"]
-      type = "Service"
+      type        = "Service"
     }
     resources = [module.s3-cloudtrail[0].arn]
   }

--- a/s3-cloudtrail.tf
+++ b/s3-cloudtrail.tf
@@ -107,7 +107,7 @@ data "aws_iam_policy_document" "log_bucket_policy" {
 
   # Sharing using AWS Organization ID
   dynamic "statement" {
-    for_each = length(var.organization_id) > 0 ? [1] : []
+    for_each = var.organization_id != null ? [1] : []
     content {
       actions = ["s3:PutObject"]
       effect  = "Allow"
@@ -130,7 +130,7 @@ data "aws_iam_policy_document" "log_bucket_policy" {
   }
 
   dynamic "statement" {
-    for_each = length(var.organization_id) > 0 ? [1] : []
+    for_each = var.organization_id != null ? [1] : []
     content {
       actions = ["s3:GetBucketAcl"]
       effect  = "Allow"

--- a/s3-elb-accesslog.tf
+++ b/s3-elb-accesslog.tf
@@ -89,7 +89,7 @@ data "aws_iam_policy_document" "elb_accesslogs_bucket_policy" {
 
   # Sharing using AWS Organization ID
   dynamic "statement" {
-    for_each = length(var.organization_id) > 0 ? [1] : []
+    for_each = var.organization_id != null ? [1] : []
     content {
       actions = ["s3:PutObject"]
       effect  = "Allow"

--- a/s3-elb-accesslog.tf
+++ b/s3-elb-accesslog.tf
@@ -22,6 +22,14 @@ module "s3-elb-accesslogs" {
   # Bucket Policy
   bucket_policy           = true
   aws_iam_policy_document = data.aws_iam_policy_document.elb_accesslogs_bucket_policy.json
+
+  # Tags
+  tags = merge(
+    try(var.s3_backup_settings["elb-accesslogs"].enable_backup, false) && length(var.s3_backup_policy) > 0 ? {
+      backup_policy = var.s3_backup_policy
+    } : {},
+    var.s3_tags
+  )
 }
 # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html
 data "aws_elb_service_account" "main" {}
@@ -65,8 +73,9 @@ data "aws_iam_policy_document" "elb_accesslogs_bucket_policy" {
     ]
   }
 
+  # Sharing using Account IDs
   dynamic "statement" {
-    for_each = { for idx, account in var.application_account_numbers : idx => account if account != "" }
+    for_each = toset(var.application_account_numbers)
     content {
       actions = ["s3:PutObject"]
       effect  = "Allow"
@@ -75,6 +84,25 @@ data "aws_iam_policy_document" "elb_accesslogs_bucket_policy" {
         type        = "AWS"
       }
       resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.resource_prefix}-${var.aws_region}-elb-accesslogs/lb/AWSLogs/${statement.value}/*"]
+    }
+  }
+
+  # Sharing using AWS Organization ID
+  dynamic "statement" {
+    for_each = length(var.organization_id) > 0 ? [1] : []
+    content {
+      actions = ["s3:PutObject"]
+      effect  = "Allow"
+      principals {
+        identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_elb_service_account.main.id}:root"]
+        type        = "AWS"
+      }
+      resources = ["arn:${data.aws_partition.current.partition}:s3:::${var.resource_prefix}-${var.aws_region}-elb-accesslogs/lb/AWSLogs/*"]
+      condition {
+        test     = "StringEquals"
+        variable = "aws:PrincipalOrgID"
+        values   = [var.organization_id]
+      }
     }
   }
 }

--- a/s3-fedrampdoc.tf
+++ b/s3-fedrampdoc.tf
@@ -14,4 +14,12 @@ module "s3-fedrampdoc" {
   logging       = true
   target_bucket = module.s3-accesslogs[0].id
   target_prefix = "fedrampdoc/"
+
+  # Tags
+  tags = merge(
+    try(var.s3_backup_settings["fedrampdoc"].enable_backup, false) && length(var.s3_backup_policy) > 0 ? {
+      backup_policy = var.s3_backup_policy
+    } : {},
+    var.s3_tags
+  )
 }

--- a/s3-installs.tf
+++ b/s3-installs.tf
@@ -14,4 +14,12 @@ module "s3-installs" {
   logging       = true
   target_bucket = module.s3-accesslogs[0].id
   target_prefix = "installs/"
+
+  # Tags
+  tags = merge(
+    try(var.s3_backup_settings["installs"].enable_backup, false) && length(var.s3_backup_policy) > 0 ? {
+      backup_policy = var.s3_backup_policy
+    } : {},
+    var.s3_tags
+  )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,7 @@ variable "default_aws_region" {
 variable "application_account_numbers" {
   description = "AWS account numbers for all application accounts that might need shared access to resources like KMS keys"
   type        = list(string)
+  default     = []
 }
 
 variable "account_number" {
@@ -124,6 +125,18 @@ variable "create_ecr_kms_key" {
   default     = true
 }
 
+variable "create_sqs_kms_key" {
+  description = "create KMS key for SQS"
+  type        = bool
+  default     = true
+}
+
+variable "kms_multi_region" {
+  description = "Indicates whether the KMS key is a multi-Region (true) or regional (false) key."
+  type        = bool
+  default     = false
+}
+
 ### S3 ###
 variable "create_s3_accesslogs_bucket" {
   description = "Create S3 Access Logs Bucket"
@@ -159,6 +172,48 @@ variable "create_s3_config_bucket" {
   description = "Create S3 AWS Config Bucket for conformance pack storage"
   type        = bool
   default     = true
+}
+
+variable "s3_backup_settings" {
+  description = "Map of S3 bucket types to their backup settings"
+  type = map(object({
+    enable_backup = bool
+  }))
+  default = {
+    accesslogs = {
+      enable_backup = false  # Assuming that a SIEM will ingest and store these logs
+    }
+    elb-accesslogs = {
+      enable_backup = false  # Assuming that a SIEM will ingest and store these logs
+    }
+    backups = {
+      enable_backup = true
+    }
+    installs = {
+      enable_backup = true
+    }
+    fedrampdoc = {
+      enable_backup = true
+    }
+    cloudtrail = {
+      enable_backup = false   # Assuming that a SIEM will ingest and store these logs
+    }
+    config = {
+      enable_backup = true
+    }
+  }
+}
+
+variable "s3_backup_policy" {
+  description = "S3 backup policy to use for S3 buckets in conjunction with AWS Backups, should match an existing policy"
+  type        = string
+  default     = null # What you specified in AWS Backups pak, may look like "aws-backup-${var.resource_prefix}-default-policy"
+}
+
+variable "s3_tags" {
+  description = "Tags to be applied to S3 buckets"
+  type        = map(object)
+  default     = {}
 }
 
 ### Misc ###

--- a/variables.tf
+++ b/variables.tf
@@ -131,6 +131,12 @@ variable "create_sqs_kms_key" {
   default     = true
 }
 
+variable "create_nfw_kms_key" {
+  description = "create KMS key for NFW"
+  type        = bool
+  default     = true
+}
+
 variable "kms_multi_region" {
   description = "Indicates whether the KMS key is a multi-Region (true) or regional (false) key."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -211,7 +211,7 @@ variable "s3_backup_settings" {
 variable "s3_backup_policy" {
   description = "S3 backup policy to use for S3 buckets in conjunction with AWS Backups, should match an existing policy"
   type        = string
-  default     = null # What you specified in AWS Backups pak, may look like "aws-backup-${var.resource_prefix}-default-policy"
+  default     = "" # What you specified in AWS Backups pak, may look like "aws-backup-${var.resource_prefix}-default-policy"
 }
 
 variable "s3_tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,8 +4,6 @@ variable "aws_region" {
   type        = string
 }
 
-variable "profile" {}
-
 variable "default_aws_region" {
   description = "The default AWS region to create resources in"
   type        = string
@@ -187,10 +185,10 @@ variable "s3_backup_settings" {
   }))
   default = {
     accesslogs = {
-      enable_backup = false  # Assuming that a SIEM will ingest and store these logs
+      enable_backup = false # Assuming that a SIEM will ingest and store these logs
     }
     elb-accesslogs = {
-      enable_backup = false  # Assuming that a SIEM will ingest and store these logs
+      enable_backup = false # Assuming that a SIEM will ingest and store these logs
     }
     backups = {
       enable_backup = true
@@ -202,7 +200,7 @@ variable "s3_backup_settings" {
       enable_backup = true
     }
     cloudtrail = {
-      enable_backup = false   # Assuming that a SIEM will ingest and store these logs
+      enable_backup = false # Assuming that a SIEM will ingest and store these logs
     }
     config = {
       enable_backup = true
@@ -218,7 +216,7 @@ variable "s3_backup_policy" {
 
 variable "s3_tags" {
   description = "Tags to be applied to S3 buckets"
-  type        = map(object)
+  type        = map(any)
   default     = {}
 }
 


### PR DESCRIPTION
# Cross-Account IAM Permissions
For S3 Buckets (where applicable) and KMS keys, I added the ability to share access to these resources using AWS Organization ID (assuming singular only): https://aws.amazon.com/blogs/security/control-access-to-aws-resources-by-using-the-aws-organization-of-iam-principals/
- I retained "application_account_numbers" for backwards compatibility and improved the for_each logic so that engineers can completely omit this variable instead of providing an empty value of "application_account_numbers = [""]": https://github.com/Coalfire-CF/terraform-aws-account-setup/issues/27

Effectively 3 use cases are supported:
1. No cross-account sharing at all.
2. Cross-account sharing is accomplished by providing a list of AWS Account IDs via "application_account_numbers".
3. Cross-account sharing is accomplished by providing a single string to "organization_id" (recommended).

# IAM
- Updated eks_node_role to use the native "aws_iam_policy_document" data source instead of jsonencode() for easier readability.

# KMS
- KMS pak version updated from v0.0.6 => v1.0.1.  v0.0.6 is a tag, but it is not a release version.  This caused issues with the ability to properly pull the pak using an SBOM script.  Latest version also provides enhancements like multi-region key replication.
- Added "nfw" and "sqs" KMS keys with appropriate permissions as it seems like these will be commonly used keys.
- Updated all "aws_iam_policy_document" data sources with a "count" meta argument which matches the appropriate "create_" boolean variables.  This prevents the data source from being created and unnecessarily cluttering both terraform state and the stdout if an engineer opts NOT to create a specific KMS key.
- Added use of "source_policy_documents" to merge KMS key policies for each KMS key.  "kms_base_and_sharing_permissions" policy contains a Base policy (root account has full control over its own key) as well as any cross-account sharing (application_account_numbers OR organization_id).  This helps with code deduplication and makes it easier to identify which IAM policies are actually required by a particular service.
- Added optional variable "kms_multi_region" with a default value of "false".  This will enable cross-region replication on KMS keys for edge use cases (possibly Enterprise clients who want cross-region Disaster Recovery).

# s3
- Added "s3_backup_settings" and "s3_backup_policy" to allow engineers to define a specific tag to enable AWS Backups for S3 buckets.  Engineers can also individually enable and disable AWS Backups for each individual bucket.
- Added "s3_tags" variable to also allow defining custom tags for S3 buckets in general (not per-bucket).
- Cross-account access to S3 Access Logs bucket is not possible, so I removed that configuration.

# s3 config bucket
I noticed an IAM Policy like this for the s3 bucket for AWS Config:
```
dynamic "statement" {
    for_each = var.application_account_numbers
    content {
      effect  = "Allow"
      actions = ["s3:GetBucketAcl", "s3:ListBucket", "s3:PutObject*"]
      resources = [
        module.s3-config[0].arn
      ]
      principals {
        type        = "Service"
        identifiers = ["config.amazonaws.com"]
      }
    }
  }
```

However, I didn't see a "statement.value" or other use of "var.application_account_numbers" anywhere within the statement block that would allow cross-account access, so all the existing IAM policy would do is duplicate the IAM policy statements with no differences.

Based on how this IAM Policy was structured, I'm assuming this is meant to enable cross-account access, so I reviewed the AWS documentation and refactored the code to allow cross-account access:
https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-policy.html#granting-access-in-another-account

