### PR TITLE
terraform fmt + adding ec2-key-pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ Copyright © 2023 Coalfire Systems Inc.
 |-- cloudtrail.tf
 |-- coalfire_logo.png
 |-- data.tf
+|-- ec2-key-pair.tf
 |-- iam.tf
 |-- kms.tf
 |-- outputs.tf

--- a/ec2-key-pair.tf
+++ b/ec2-key-pair.tf
@@ -1,0 +1,23 @@
+resource "tls_private_key" "ssh_key" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "aws_key_pair" "generated_key" {
+  provider   = aws.pak-testing  #Replace "pak-testing" with proper provider name
+  key_name   = "prefix-fedramp-mgmt-gov-key" #replace prefix with proper name
+  public_key = tls_private_key.ssh_key.public_key_openssh
+}
+
+# Store the private key in AWS Secrets Manager
+resource "aws_secretsmanager_secret" "keypair_secret" {
+  provider   = aws.pak-testing  #Replace "pak-testing" with proper provider name
+  name       = "/management/fedramp-mgmt-gov/prefix-ec2-key-pair" #replace with proper prefix
+  kms_key_id = module.setup.sm_kms_key_id
+}
+
+resource "aws_secretsmanager_secret_version" "keypair_secret_version" {
+  provider      = aws.pak-testing  #Replace "pak-testing" with proper provider name
+  secret_id     = aws_secretsmanager_secret.keypair_secret.id
+  secret_string = tls_private_key.ssh_key.private_key_pem
+}

--- a/iam.tf
+++ b/iam.tf
@@ -1,4 +1,4 @@
 resource "aws_iam_service_linked_role" "autoscale" {
-  count = var.create_autoscale_role ? 1 : 0
+  count            = var.create_autoscale_role ? 1 : 0
   aws_service_name = "autoscaling.amazonaws.com"
 }

--- a/kms.tf
+++ b/kms.tf
@@ -71,7 +71,7 @@ module "ebs_kms_key" {
 }
 
 data "aws_iam_policy_document" "ebs_key" {
-  count = (var.create_ebs_kms_key || var.create_autoscale_role) ? 1 : 0 
+  count = (var.create_ebs_kms_key || var.create_autoscale_role) ? 1 : 0
 
   #checkov:skip=CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
   #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"

--- a/s3-cloudtrail.tf
+++ b/s3-cloudtrail.tf
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "log_bucket_policy" {
   count = var.create_cloudtrail && var.default_aws_region == var.aws_region ? 1 : 0
 
   statement {
-    sid = "AWSCloudTrailWrite"
+    sid     = "AWSCloudTrailWrite"
     actions = ["s3:PutObject"]
     effect  = "Allow"
     principals {
@@ -54,7 +54,7 @@ data "aws_iam_policy_document" "log_bucket_policy" {
   }
 
   statement {
-    sid = "AWSCloudTrailAclCheck"
+    sid     = "AWSCloudTrailAclCheck"
     actions = ["s3:GetBucketAcl"]
     effect  = "Allow"
     principals {
@@ -97,7 +97,7 @@ data "aws_iam_policy_document" "log_bucket_policy" {
   }
 
   dynamic "statement" {
-    for_each = toset(var.application_account_numbers)    
+    for_each = toset(var.application_account_numbers)
     content {
       sid     = "AWSCloudTrailAclGET-${statement.key}"
       actions = ["s3:GetBucketAcl"]
@@ -110,7 +110,7 @@ data "aws_iam_policy_document" "log_bucket_policy" {
     }
   }
 
-# Sharing using AWS Organization ID
+  # Sharing using AWS Organization ID
   dynamic "statement" {
     for_each = var.organization_id != null ? [1] : []
     content {

--- a/security-core.tf
+++ b/security-core.tf
@@ -8,5 +8,5 @@ module "security-core" {
   resource_prefix             = var.resource_prefix
 
   # KMS Keys
-  s3_kms_key_arn     = module.s3_kms_key[0].kms_key_arn
+  s3_kms_key_arn = module.s3_kms_key[0].kms_key_arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -53,8 +53,8 @@ variable "cloudwatch_log_group_retention_in_days" {
 ### AWS AutoScale IAM Role ###
 variable "create_autoscale_role" {
   description = "Create AWS Autoscale IAM Role (needed for any autoscaling aws resources)"
-  type = bool
-  default = true #If AWSServiceRoleForAutoScaling role already exists in environment will have to set this var to false where the module is called
+  type        = bool
+  default     = true #If AWSServiceRoleForAutoScaling role already exists in environment will have to set this var to false where the module is called
 }
 
 ### KMS ###


### PR DESCRIPTION
Ran a terraform fmt and it cleaned up several files. 

Suggesting that we add the ec2-key-pair.tf file to account setup. I couldn't find this documented in the account-setup pak. It would be nice to have the ec2 key pair deployed with the account setup. 

Here is a code example from a project where this was used/tested: https://github.com/Coalfire-CF/datarobot-gov/blob/main/aws/gov-accounts/production/fedramp-mgmt-plane/account-setup/ec2-key-pair.tf.

The EC2 key pair is used later in the build during application setup (e.g. jira, burp, etc.). This wasn't completed during account set up on Bugcrowd and we ran into issues we were trying to prep/deploy applications. 