### PR TITLE
Add permissions for Packer IAM.

### DIFF
--- a/packer_iam.tf
+++ b/packer_iam.tf
@@ -142,6 +142,19 @@ data "aws_iam_policy_document" "packer_policy_document" {
     ]
     resources = ["*"]
   }
+
+  # Not officially part of the permission set provided by Hashicorp, but still generally needed by all EC2 using IMDSv2
+  # and you want to use metadata and/or IAM permissions for something else (scripting, Ansible, etc.)
+  statement {
+    sid    = "IMDSv2Permissions"
+    effect = "Allow"
+    actions = [
+      "ec2:MetadataHttpEndpoint",
+      "ec2:MetadataHttpPutResponseHopLimit",
+      "ec2:MetadataHttpTokens"
+    ]
+    resources = ["*"]
+  }
 }
 
 


### PR DESCRIPTION
# Packer
- Adds IMDSv2 permissions to Packer IAM Policy.

What doesn't work if this is omitted:
Ansible partition_disk role
```
- name: Gather EC2 metadata facts
  amazon.aws.ec2_metadata_facts:

- name: Get EBS volume information
  amazon.aws.ec2_vol_info:
    region: "{{ ansible_ec2_placement_region  }}"
    filters:
      attachment.instance-id: "{{ ansible_ec2_instance_id }}"
      attachment.device: "{{ disk_to_partition }}"
  register: volumes_info
  delegate_to: localhost
```

Ansible (as well as scripting) will fail without clear errors when you attempt to use the IAM instance profile to do certain things like reading AWS Secrets or metadata.

The code snippet above attempts to map a device volume name in AWS (/dev/sdb) to a specific volume ID (vol-0a86b3eee6bed0d18) instead of attempting to hardcode or guess what the device name will be in the OS (/dev/nvme1n1), which might be subject to change depending on the distribution.

Additional use cases for this might be grabbing a Root CA cert from Secrets Manager, or agent installation that requires a password stored in Secrets Manager.