### PR TITLE
Add new config bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ SSO-based authentication (via IAM Identity Center SSO):
 | <a name="module_s3-elb-accesslogs"></a> [s3-elb-accesslogs](#module\_s3-elb-accesslogs) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.4 |
 | <a name="module_s3-fedrampdoc"></a> [s3-fedrampdoc](#module\_s3-fedrampdoc) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.4 |
 | <a name="module_s3-installs"></a> [s3-installs](#module\_s3-installs) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.4 |
+| <a name="module_s3_config_conformance_pack"></a> [s3\_config\_conformance\_pack](#module\_s3\_config\_conformance\_pack) | github.com/Coalfire-CF/terraform-aws-s3 | v1.0.4 |
 | <a name="module_s3_kms_key"></a> [s3\_kms\_key](#module\_s3\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
 | <a name="module_security-core"></a> [security-core](#module\_security-core) | github.com/Coalfire-CF/terraform-aws-securitycore | v0.0.24 |
 | <a name="module_sm_kms_key"></a> [sm\_kms\_key](#module\_sm\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
@@ -322,6 +323,7 @@ SSO-based authentication (via IAM Identity Center SSO):
 | [aws_kms_grant.packer_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_grant) | resource |
 | [aws_s3_bucket_policy.cloudtrail_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.config_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_policy.conformance_pack_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_secretsmanager_secret.keypair_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.keypair_secret_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [tls_private_key.ssh_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
@@ -341,6 +343,7 @@ SSO-based authentication (via IAM Identity Center SSO):
 | [aws_iam_policy_document.packer_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_accesslogs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_config_bucket_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.s3_config_conformance_pack_policy_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.secrets_manager_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sns_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/s3-aws-config.tf
+++ b/s3-aws-config.tf
@@ -199,7 +199,7 @@ module "s3_config_conformance_pack" {
 
   # Tags
   tags = merge(
-    try(var.s3_backup_settings["config-conformance"].enable_backup, false) && length(var.s3_backup_policy) > 0 ? {  #leave as config or config-conformance?
+    try(var.s3_backup_settings["config-conformance"].enable_backup, false) && length(var.s3_backup_policy) > 0 ? {
       backup_policy = var.s3_backup_policy
     } : {},
     var.s3_tags

--- a/s3-aws-config.tf
+++ b/s3-aws-config.tf
@@ -1,3 +1,4 @@
+## Primary Config Bucket ##
 module "s3-config" {
   count = var.create_s3_config_bucket ? 1 : 0
 
@@ -159,6 +160,187 @@ data "aws_iam_policy_document" "s3_config_bucket_policy_doc" {
       actions = ["s3:PutObject"]
       resources = [
         "${module.s3-config[0].arn}/*"
+      ]
+      principals {
+        type        = "Service"
+        identifiers = ["config.amazonaws.com"]
+      }
+      condition {
+        test     = "StringEquals"
+        variable = "s3:x-amz-acl"
+        values   = ["bucket-owner-full-control"]
+      }
+      condition {
+        test     = "StringEquals"
+        variable = "aws:PrincipalOrgID"
+        values   = [var.organization_id]
+      }
+    }
+  }
+}
+
+## Config Conformance Pack Bucket ##
+module "s3_config_conformance_pack" {
+  count = var.create_s3_config_bucket ? 1 : 0
+
+  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.4"
+
+  name                    = "awsconfigconforms-${var.resource_prefix}-${var.aws_region}"
+  kms_master_key_id       = module.s3_kms_key[0].kms_key_arn
+  attach_public_policy    = false
+  block_public_acls       = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  # S3 Access Logs
+  logging       = true
+  target_bucket = module.s3-accesslogs[0].id
+  target_prefix = "config-conformance/"
+
+  # Tags
+  tags = merge(
+    try(var.s3_backup_settings["config-conformance"].enable_backup, false) && length(var.s3_backup_policy) > 0 ? {  #leave as config or config-conformance?
+      backup_policy = var.s3_backup_policy
+    } : {},
+    var.s3_tags
+  )
+}
+
+resource "aws_s3_bucket_policy" "conformance_pack_bucket_policy" {
+  count  = var.create_s3_config_bucket && var.default_aws_region == var.aws_region ? 1 : 0
+  bucket = module.s3_config_conformance_pack[0].id
+
+  policy = data.aws_iam_policy_document.s3_config_conformance_pack_bucket_policy_doc[0].json
+}
+
+data "aws_iam_policy_document" "s3_config_conformance_pack_policy_doc" {
+  count = var.create_s3_config_bucket && var.default_aws_region == var.aws_region ? 1 : 0
+
+  # https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-policy.html#granting-access-in-another-account
+
+  # Base Permissions
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetBucketAcl",
+      "s3:ListBucket"
+    ]
+    resources = [
+      module.s3_config_conformance_pack[0].arn
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [var.account_number]
+    }
+  }
+
+  statement {
+    effect  = "Allow"
+    actions = ["s3:PutObject"]
+    resources = [
+      "${module.s3_config_conformance_pack[0].arn}/*"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [var.account_number]
+    }
+  }
+
+  # Sharing with AWS Account IDs
+  dynamic "statement" {
+    for_each = length(var.application_account_numbers) > 0 ? [1] : []
+    content {
+      effect = "Allow"
+      actions = [
+        "s3:GetBucketAcl",
+        "s3:ListBucket"
+      ]
+      resources = [
+        module.s3_config_conformance_pack[0].arn
+      ]
+      principals {
+        type        = "Service"
+        identifiers = ["config.amazonaws.com"]
+      }
+      condition {
+        test     = "StringEquals"
+        variable = "aws:SourceAccount"
+        values   = var.application_account_numbers
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = length(var.application_account_numbers) > 0 ? [1] : []
+    content {
+      effect  = "Allow"
+      actions = ["s3:PutObject"]
+      resources = [
+        "${module.s3_config_conformance_pack[0].arn}/*"
+      ]
+      principals {
+        type        = "Service"
+        identifiers = ["config.amazonaws.com"]
+      }
+      condition {
+        test     = "StringEquals"
+        variable = "s3:x-amz-acl"
+        values   = ["bucket-owner-full-control"]
+      }
+      condition {
+        test     = "StringEquals"
+        variable = "aws:SourceAccount"
+        values   = var.application_account_numbers
+      }
+    }
+  }
+
+  # Sharing with AWS Organization ID
+  dynamic "statement" {
+    for_each = var.organization_id != null ? [1] : []
+    content {
+      effect = "Allow"
+      actions = [
+        "s3:GetBucketAcl",
+        "s3:ListBucket"
+      ]
+      resources = [
+        module.s3_config_conformance_pack[0].arn
+      ]
+      principals {
+        type        = "Service"
+        identifiers = ["config.amazonaws.com"]
+      }
+      condition {
+        test     = "StringEquals"
+        variable = "aws:PrincipalOrgID"
+        values   = [var.organization_id]
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = var.organization_id != null ? [1] : []
+    content {
+      effect  = "Allow"
+      actions = ["s3:PutObject"]
+      resources = [
+        "${module.s3_config_conformance_pack[0].arn}/*"
       ]
       principals {
         type        = "Service"


### PR DESCRIPTION
AWS Config has a bucket requirement for conformance packs. Bucket name must start with "awsconfigconforms"

Copied the original s3 bucket code and pasted below to create the second bucket. updated naming to align with module name