### PR TITLE
fix: kms mod reference name

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ SSO-based authentication (via IAM Identity Center SSO):
 | <a name="module_config_kms_key"></a> [config\_kms\_key](#module\_config\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
 | <a name="module_default_kms_key"></a> [default\_kms\_key](#module\_default\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
 | <a name="module_ebs_kms_key"></a> [ebs\_kms\_key](#module\_ebs\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
-| <a name="module_ecr_kms_key"></a> [ecr\_kms\_key](#module\_ecr\_kms\_key) | github.com/Coalfire-CF/ACE-AWS-KMS | v1.0.1 |
+| <a name="module_ecr_kms_key"></a> [ecr\_kms\_key](#module\_ecr\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
 | <a name="module_lambda_kms_key"></a> [lambda\_kms\_key](#module\_lambda\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
 | <a name="module_nfw_kms_key"></a> [nfw\_kms\_key](#module\_nfw\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
 | <a name="module_rds_kms_key"></a> [rds\_kms\_key](#module\_rds\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
@@ -303,7 +303,7 @@ SSO-based authentication (via IAM Identity Center SSO):
 | <a name="module_security-core"></a> [security-core](#module\_security-core) | github.com/Coalfire-CF/terraform-aws-securitycore | v0.0.24 |
 | <a name="module_sm_kms_key"></a> [sm\_kms\_key](#module\_sm\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
 | <a name="module_sns_kms_key"></a> [sns\_kms\_key](#module\_sns\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
-| <a name="module_sqs_kms_key"></a> [sqs\_kms\_key](#module\_sqs\_kms\_key) | github.com/Coalfire-CF/ACE-AWS-KMS | v1.0.1 |
+| <a name="module_sqs_kms_key"></a> [sqs\_kms\_key](#module\_sqs\_kms\_key) | github.com/Coalfire-CF/terraform-aws-kms | v1.0.1 |
 
 ## Resources
 

--- a/kms.tf
+++ b/kms.tf
@@ -445,7 +445,7 @@ data "aws_iam_policy_document" "config_key" {
 module "ecr_kms_key" {
   count = var.create_ecr_kms_key ? 1 : 0
 
-  source                = "github.com/Coalfire-CF/ACE-AWS-KMS?ref=v1.0.1"
+  source                = "github.com/Coalfire-CF/terraform-aws-kms?ref=v1.0.1"
   resource_prefix       = var.resource_prefix
   kms_key_resource_type = "ecr"
   key_policy            = data.aws_iam_policy_document.ecr_kms_policy[0].json
@@ -467,7 +467,7 @@ data "aws_iam_policy_document" "ecr_kms_policy" {
 module "sqs_kms_key" {
   count = var.create_sqs_kms_key ? 1 : 0
 
-  source                = "github.com/Coalfire-CF/ACE-AWS-KMS?ref=v1.0.1"
+  source                = "github.com/Coalfire-CF/terraform-aws-kms?ref=v1.0.1"
   resource_prefix       = var.resource_prefix
   kms_key_resource_type = "sqs"
   key_policy            = data.aws_iam_policy_document.sqs_key[0].json


### PR DESCRIPTION
-Break fix for the SBOM module to work KMS module reference to old naming convention