### PR TITLE
fix: update name syntax for s3 config bucket

### DIFF
--- a/s3-aws-config.tf
+++ b/s3-aws-config.tf
@@ -4,7 +4,7 @@ module "s3-config" {
 
   source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.4"
 
-  name                    = local.config_bucket_name
+  name                    = "awsconfigconforms-${var.resource_prefix}-${aws_region}"
   kms_master_key_id       = module.s3_kms_key[0].kms_key_arn
   attach_public_policy    = false
   block_public_acls       = true


### PR DESCRIPTION
following new syntax "awsconfigconforms" for S3 bucket

https://docs.aws.amazon.com/config/latest/developerguide/cpack-prerequisites.html#:~:text=When%20deploying%20conformance%20packs%20to%20an%20organization%2C%20the%20name%20of%20the%20delivery%20Amazon%20S3%20bucket%20should%20start%20with%20awsconfigconforms.